### PR TITLE
Add parameter disableStructuralMinification

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(content) {
 	var root = query.root;
 	var tree = csso.parse(content, "stylesheet");
 	if(tree && this && this.minimize) {
-		tree = csso.compress(tree);
+		tree = csso.compress(tree, query.disableStructuralMinification);
 		tree = csso.cleanInfo(tree);
 	}
 


### PR DESCRIPTION
Adds the ability to use the disableStructuralMinification parameter when calling css-loader:

``` js
module.exports = {
  module: {
    loaders: [
      { test: /\.css/, loader: "style-loader!css-loader?disableStructuralMinification" },
      { test: /\.png/, loader: "url-loader?limit=100000&mimetype=image/png" },
      { test: /\.jpg/, loader: "file-loader" }
    ]
  }
};
```

lf disableStructuralMinification is true, csso will not do structural magnification which is destructive, in some cases breaking @keyframe rules.
