### PR TITLE
Support root=~ for interpreting root urls as modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The result is:
 
 * `url(/image.png)` => `require("./image.png")`
 
+If you want your urls that start with `/` to be resolved as modules, specify `root=~`:
+
+* `url(/image.png)` => `require("image.png")`
+
 ### SourceMaps
 
 To include SourceMaps set the `sourceMap` query param.

--- a/index.js
+++ b/index.js
@@ -41,18 +41,23 @@ module.exports = function(content) {
 	css = css.replace(uriRegExp, function(str) {
 		var match = /^%CSSURL\[%(["']?(.*?)["']?)%\]CSSURL%$/.exec(JSON.parse('"' + str + '"'));
 		var url = loaderUtils.parseString(match[2]);
-		if(!loaderUtils.isUrlRequest(match[2], root)) return JSON.stringify(match[1]).replace(/^"|"$/g, "");
+		var urlRoot = root;
+		if (urlRoot === "~") {
+			url = url.replace(/^\//, "~");
+			urlRoot = null;
+		}
+		if(!loaderUtils.isUrlRequest(match[2], urlRoot)) return JSON.stringify(match[1]).replace(/^"|"$/g, "");
 		var idx = url.indexOf("?#");
 		if(idx < 0) idx = url.indexOf("#");
 		if(idx > 0) {
 			// in cases like url('webfont.eot?#iefix')
 			var request = url.substr(0, idx);
-			return "\"+require(" + JSON.stringify(loaderUtils.urlToRequest(request, root)) + ")+\"" + url.substr(idx);
+			return "\"+require(" + JSON.stringify(loaderUtils.urlToRequest(request, urlRoot)) + ")+\"" + url.substr(idx);
 		} else if(idx === 0) {
 			// only hash
 			return JSON.stringify(match[1]).replace(/^"|"$/g, "");
 		}
-		return "\"+require(" + JSON.stringify(loaderUtils.urlToRequest(url, root)) + ")+\"";
+		return "\"+require(" + JSON.stringify(loaderUtils.urlToRequest(url, urlRoot)) + ")+\"";
 	});
 	if(query.sourceMap && !minimize) {
 		var cssRequest = loaderUtils.getRemainingRequest(this);

--- a/test/urlTest.js
+++ b/test/urlTest.js
@@ -107,6 +107,9 @@ describe("url", function() {
 	test("background img absolute with root", ".class { background: green url(/img.png) xyz }", [
 		[1, ".class { background: green url({./img.png}) xyz }", ""]
 	], "?root=.");
+	test("background img absolute with root = ~", ".class { background: green url(/img.png) xyz }", [
+		[1, ".class { background: green url({img.png}) xyz }", ""]
+	], "?root=~");
 	test("background img external",
 		".class { background: green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) xyz }", [
 		[1, ".class { background: green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) xyz }", ""]


### PR DESCRIPTION
Does what it says. If you are working with a bunch of existing CSS files that have URLs that you really want to be interpreting as modules, then you can now use root=~ to do that.
