### PR TITLE
expose style rules/properties to js exporter

### DIFF
--- a/lib/compile-exports.js
+++ b/lib/compile-exports.js
@@ -11,19 +11,55 @@ module.exports = function compileExports(result, importItemMatcher, camelCaseKey
     return "";
   }
 
+  var exportRules = {}
+  Object.keys(result.exports).forEach(function(key) {
+    var value = result.exports[key];
+    var index = value.indexOf(" ")
+    if (index > 0) value = value.slice(0, index);
+    var rule = result.rules["."+value]
+
+    var camelCaseRule = {};
+    Object.keys(rule).forEach(function(key) {
+      var value = rule[key];
+      key = camelCase(key)
+      camelCaseRule[key] = value;
+    });
+
+    if (/[\w_][\w\d_]*/.test(key)) {
+      exportRules[key] = camelCaseRule;
+    }
+    if (camelCaseKeys === true) {
+      var _key = camelCase(key);
+      if (_key !== key) {
+        exportRules[key] = camelCaseRule;
+      }
+    } else if (camelCaseKeys === 'dashes') {
+      var _key = dashesCamelCase(key);
+      if (_key !== key) {
+        exportRules[key] = camelCaseRule;
+      }
+    }
+  });
+
   var exportJs = Object.keys(result.exports).reduce(function(res, key) {
     var valueAsString = JSON.stringify(result.exports[key]);
     valueAsString = valueAsString.replace(result.importItemRegExpG, importItemMatcher);
-    res.push("\t" + JSON.stringify(key) + ": " + valueAsString);
-
-    if (camelCaseKeys === true) {
-      res.push("\t" + JSON.stringify(camelCase(key)) + ": " + valueAsString);
-    } else if (camelCaseKeys === 'dashes') {
-      res.push("\t" + JSON.stringify(dashesCamelCase(key)) + ": " + valueAsString);
+    if (/[\w_][\w\d_]*/.test(key)) {
+      res.push("\t" + JSON.stringify(key) + ": " + valueAsString);
     }
-
+    if (camelCaseKeys === true) {
+      var _key = camelCase(key);
+      if (_key !== key) {
+        res.push("\t" + JSON.stringify(_key) + ": " + valueAsString);
+      }
+    } else if (camelCaseKeys === 'dashes') {
+      var _key = dashesCamelCase(key);
+      if (_key !== key) {
+        res.push("\t" + JSON.stringify(_key) + ": " + valueAsString);
+      }
+    }
     return res;
-  }, []).join(",\n");
+  }, ["\t\"__styles__\": " + JSON.stringify(exportRules)]).join(",\n");
 
   return "{\n" + exportJs + "\n}";
 };

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -196,7 +196,20 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 			annotation: false
 		}
 	}).then(function(result) {
+        var rules = {};
+        result.root.nodes.forEach(function(node) {
+            if (node.type == "rule") {
+                var styles = {};
+                node.nodes.forEach(function(xttr) {
+                    if (xttr.type == "decl") {
+                        styles[xttr.prop] = xttr.value;
+                    }
+                });
+                rules[node.selector] = styles;
+            }
+        })
 		callback(null, {
+            rules: rules, /* expose style rules to export */
 			source: result.css,
 			map: result.map && result.map.toJSON(),
 			exports: parserOptions.exports,


### PR DESCRIPTION
Comparing to React inline CSS, I found not only css classname that needed, but css properties in class referenced too. So the final solution is taking advantage of css coding, and easy to be referenced of classnames, properties, etc.

Signed-off-by: Karfield Chen kf2@karfield.com
