### PR TITLE
feat: add `asString` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,51 @@ Usage:
 require('file.css').className
 ```
 
+## As String
+
+By default the loader injects a function into the webpack bundle that exports the compiled css as a string. The `asString` query param will export the compiled css as an actual string into the bundle.
+
+Example:
+
+```javascript
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+exports = module.exports = __webpack_require__(1)();
+// imports
+
+
+// module
+exports.push([module.i, ".clear{ clear: both; }", ""]);
+
+// exports
+
+
+/***/ },
+```
+
+By setting the `asString` param to true.
+
+```javascript
+{
+  test: /\.css$/,
+  loaders: [
+    {
+      loader: 'css-loader',
+      query: {
+        asString: true
+      }
+    }
+  ]
+}
+```
+
+The bundle will have an actual string export:
+
+```javascript
+module.exports = ".clear{ clear: both; }";
+```
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -112,13 +112,18 @@ module.exports = function(content, map) {
 			moduleJs = "exports.push([module.id, " + cssAsString + ", \"\"]);";
 		}
 
-		// embed runtime
-		callback(null, "exports = module.exports = require(" + loaderUtils.stringifyRequest(this, require.resolve("./css-base.js")) + ")();\n" +
-			"// imports\n" +
-			importJs + "\n\n" +
-			"// module\n" +
-			moduleJs + "\n\n" +
-			"// exports\n" +
-			exportJs);
+		if (!query.asString) {
+			// embed runtime
+			callback(null, "exports = module.exports = require(" + loaderUtils.stringifyRequest(this, require.resolve("./css-base.js")) + ")();\n" +
+				"// imports\n" +
+				importJs + "\n\n" +
+				"// module\n" +
+				moduleJs + "\n\n" +
+				"// exports\n" +
+				exportJs);
+		}
+		else {
+			callback(null, 'module.exports = ' + cssAsString + ';');
+		}
 	}.bind(this));
 };

--- a/test/asStringTest.js
+++ b/test/asStringTest.js
@@ -1,0 +1,11 @@
+/*globals describe */
+
+var test = require("./helpers").test;
+
+describe("asString", function() {
+	test("returns string", ".clear { clear: both; }",
+  '.clear { clear: both; }', 
+  "?asString=true",
+  ""
+  );
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Feature. Inject an actual string export into webpack bundle.

**Did you add tests for your changes?**
Yes.

**If relevant, did you update the README?**
Yes.

**Summary**
I had a requirement for this loader to return the value of `cssAsString`. This can prove to be useful for chaining loaders after css-loader that require the css string as the content.

**Does this PR introduce a breaking change?**
No

