### PR TITLE
Enable getLocalIdent in global options

### DIFF
--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -140,7 +140,9 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 	var forceMinimize = query.minimize;
 	var minimize = typeof forceMinimize !== "undefined" ? !!forceMinimize : options.minimize;
 
-	var customGetLocalIdent = query.getLocalIdent || getLocalIdent;
+	var customGetLocalIdent = query.getLocalIdent ||
+		(options.loaderContext.options.css && options.loaderContext.options.css.getLocalIdent) ||
+		getLocalIdent;
 	
 	var parserOptions = {
 		root: root,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR will enable global options, and thus can give a workaround to https://github.com/webpack/css-loader/issues/389 : just put getLocalIdent in global options via LoaderOptionsPlugin

**Did you add tests for your changes?**

Yes, in my project, I use a patch to this loader, and works fine.

**If relevant, did you update the README?**

Not yet. cause it still has space to improve: enable other options in global. but it should be judged by project owner.

**Summary**

See above.

https://github.com/webpack/css-loader/issues/389

**Does this PR introduce a breaking change?**

No

**Other information**

This will make it possible to work with webpack2 and extract-text-webpack-plugin
