### PR TITLE
Attempt creating globally unique module id's

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var path = require("path");
+var rs = require('random-strings');
 var loaderUtils = require("loader-utils");
 var processCss = require("./processCss");
 var getImportPrefix = require("./getImportPrefix");
@@ -46,7 +47,7 @@ module.exports = function(content, map) {
 			return true;
 		}).map(function(imp) {
 			if(!loaderUtils.isUrlRequest(imp.url, root)) {
-				return "exports.push([module.id, " +
+				return "exports.push(['" + rs.hex(10) +"', " +
 					JSON.stringify("@import url(" + imp.url + ");") + ", " +
 					JSON.stringify(imp.mediaQuery) + "]);";
 			} else {
@@ -107,9 +108,9 @@ module.exports = function(content, map) {
 			}
 			map.file = map.file.split("!").pop();
 			map = JSON.stringify(map);
-			moduleJs = "exports.push([module.id, " + cssAsString + ", \"\", " + map + "]);";
+			moduleJs = "exports.push(['" + rs.hex(10) + "', " + cssAsString + ", \"\", " + map + "]);";
 		} else {
-			moduleJs = "exports.push([module.id, " + cssAsString + ", \"\"]);";
+			moduleJs = "exports.push(['" + rs.hex(10) + "', " + cssAsString + ", \"\"]);";
 		}
 
 		// embed runtime

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postcss-modules-local-by-default": "^1.0.1",
     "postcss-modules-scope": "^1.0.0",
     "postcss-modules-values": "^1.1.0",
+    "random-strings": "0.0.1",
     "source-list-map": "^0.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

bugfix

**Did you add tests for your changes?**

Not yet, I'm interested to see the level of buy-in to these changes before spending time updating/writing new tests

**If relevant, did you update the README?**

Same as above. 

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Module IDs are used to determine whether a css module has been loaded or not. However, webpack's `module.id` is only unique per webpack build. In our use case, we are trying to distribute css-modules as npm packages which are bundled separately. This causes collisions for consumers when bundling more than one dependency.

Example:

project-a's export looks like:
```javascript
[[1, '/* css for project-a omitted */', null]]
```
project-b's export looks like:
```javascript
[[1, '/* css for project-b omitted */', null]]
```

When project-c tries to import project-a and project-b, it determines that project-b is already loaded because it has the same id as project-a. [See here](https://github.com/webpack/css-loader/blob/master/lib/css-base.js#L39)

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

I don't think so but I don't know all of the consumption contracts.

**Other information**

We are using the query string `importLoaders=false` to bypass the css-loader on imports. This is important to us because we are distributing modules as npm packages and we think that post-bundle js files is the most scalable distribution format.

## This is a WIP

### Todo:
- [ ] Confirm whether this type of change is a good change or not.
- [ ] Update tests
