### PR TITLE
refactor: evaluate values before extracting imports

### DIFF
--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -164,8 +164,8 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 				return url;
 			}
 		}),
-		extractImports(),
 		modulesValues,
+		extractImports(),
 		modulesScope({
 			generateScopedName: function generateScopedName (exportName) {
 				return customGetLocalIdent(options.loaderContext, localIdentName, exportName, {

--- a/test/localTest.js
+++ b/test/localTest.js
@@ -170,6 +170,37 @@ describe("local", function() {
 			}
 		}
 	});
+	testLocal("composes from import in @value", "@value colors: './colors.css';.className { composes: blue from colors; text-align: right; }", [
+		[2, "._blue { color: blue; }", ""],
+		[1, "._className { text-align: right; }", ""]
+	], {
+		"colors": "'./colors.css'",
+		"className": "_className _blue"
+	}, "?module&localIdentName=_[local]", {
+		"./colors.css":  (function() {
+			var r = [ [2, "._blue { color: blue; }", ""] ];
+			r.locals = {
+				blue: "_blue"
+			};
+			return r;
+		}())
+	});
+	testLocal("composes from @value imported in @value", "@value colors: './colors.css';@value blue from colors;.className { composes: blue; text-align: right; }", [
+		[2, "._blue { color: blue; }", ""],
+		[1, "._className { text-align: right; }", ""]
+	], {
+		"colors": "'./colors.css'",
+		"blue": "_blue",
+		"className": "_className _blue"
+	}, "?module&localIdentName=_[local]", {
+		"./colors.css":  (function() {
+			var r = [ [2, "._blue { color: blue; }", ""] ];
+			r.locals = {
+				blue: "_blue"
+			};
+			return r;
+		}())
+	});
 	testLocal("issue-109", ".bar-1 { color: red; }", [
 		[1, ".file--bar-1--2JvfJ { color: red; }", ""]
 	], {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Applies postcss-modules-values before postcss-modules-extract-imports, in order to allow code such as:

    @value colors: './colors.css';
    .className: { composes blue from colors; }

**Did you add tests for your changes?**
Yes