### PR TITLE
fix: do not export duplicate keys

### DIFF
--- a/lib/compile-exports.js
+++ b/lib/compile-exports.js
@@ -14,14 +14,23 @@ module.exports = function compileExports(result, importItemMatcher, camelCaseKey
   var exportJs = Object.keys(result.exports).reduce(function(res, key) {
     var valueAsString = JSON.stringify(result.exports[key]);
     valueAsString = valueAsString.replace(result.importItemRegExpG, importItemMatcher);
-    res.push("\t" + JSON.stringify(key) + ": " + valueAsString);
-
-    if (camelCaseKeys === true) {
-      res.push("\t" + JSON.stringify(camelCase(key)) + ": " + valueAsString);
-    } else if (camelCaseKeys === 'dashes') {
-      res.push("\t" + JSON.stringify(dashesCamelCase(key)) + ": " + valueAsString);
+    function addEntry(k) {
+      res.push("\t" + JSON.stringify(k) + ": " + valueAsString);
     }
+    addEntry(key);
 
+    var targetKey;
+    if (camelCaseKeys === true) {
+      targetKey = camelCase(key);
+      if (targetKey !== key) {
+        addEntry(targetKey);
+      }
+    } else if (camelCaseKeys === 'dashes') {
+      targetKey = dashesCamelCase(key);
+      if (targetKey !== key) {
+        addEntry(targetKey);
+      }
+    }
     return res;
   }, []).join(",\n");
 

--- a/test/camelCaseTest.js
+++ b/test/camelCaseTest.js
@@ -1,6 +1,7 @@
 /*globals describe */
 
 var test = require("./helpers").test;
+var testRaw = require("./helpers").testRaw;
 
 describe("camelCase", function() {
 	var css = ".btn-info_is-disabled { color: blue; }";
@@ -21,4 +22,7 @@ describe("camelCase", function() {
 	test("with", css, exports.with, "?modules");
 	test("without", css, exports.without, "?modules&camelCase");
 	test("dashes", css, exports.dashes, "?modules&camelCase=dashes");
+
+	testRaw("withoutRaw", '.a {}', 'exports.locals = {\n\t"a": "_1buUQJccBRS2-2i27LCoDf"\n};', "?modules&camelCase");
+	testRaw("dashesRaw", '.a {}', 'exports.locals = {\n\t"a": "_1buUQJccBRS2-2i27LCoDf"\n};', "?modules&camelCase=dashes");
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -32,6 +32,10 @@ function assetEvaluated(output, result, modules) {
 	exports.should.be.eql(result);
 }
 
+function assertRaw(output, result) {
+	output.should.containEql(result);
+}
+
 function runLoader(loader, input, map, addOptions, callback) {
 	var opt = {
 		options: {
@@ -68,6 +72,18 @@ exports.test = function test(name, input, result, query, modules) {
 		});
 	});
 };
+
+exports.testRaw = function testRaw(name, input, result, query, modules) {
+	it(name, function(done) {
+		runLoader(cssLoader, input, undefined, !query || typeof query === "string" ? {
+			query: query
+		} : query, function(err, output) {
+			if(err) return done(err);
+			assertRaw(output, result, modules);
+			done();
+		});
+	});
+}
 
 exports.testError = function test(name, input, onError) {
 	it(name, function(done) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix, it makes sure that keys that are the same in different case styles (e.g. dashed, camelCase, dashedCamelCase) are not added to the resulting output when `?camelCase` is enabled.

E.g. a class name `.bla` would be `bla` as a default, but also `bla` in camelCase whereas `.my-bla` would yield `my-bla` and `myBla`. Currently the constructed document for the locals contains two entries, like this:
```json
{
  "bla": "_1L-rnCOXCE_7H94L5XT4uB",
  "bla": "_1L-rnCOXCE_7H94L5XT4uB",
}
```
if `camelCase` is enabled.

**Did you add tests for your changes?**

No, because the test helper uses JSON deserialization, which removes the dupe.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When using CSS modules with Typescript for example, you encounter something like this:
```
ERROR in /Users/joscha/dev/web-ui/src/ui/button/button.css.ts
(11,2): error TS2300: Duplicate identifier '"defaultFontStack"'.

ERROR in /Users/joscha/dev/web-ui/src/ui/button/button.css.ts
(13,2): error TS2300: Duplicate identifier '"button"'.
```
Also, the resulting output in the bundle is 50% bigger than it has to be if only class names are used that are `className === camelCase(className)`.

**Does this PR introduce a breaking change?**
No