### PR TITLE
feat: add option to warn at runtime when non-existent properties are accessed

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -92,7 +92,7 @@ module.exports = function(content, map) {
 				exportJs = "exports.locals = new Proxy(" + exportJs + "," +
 					"{ get(target, property) { " +
 					"if (typeof target[property] !== 'string' && property !== '__esModule') {" +
-					"console.warn(`Attempted to access non-existent className '${property} on CSS module'`)" +
+					"console.warn('Attempted to access non-existent class name' + property + ' on CSS module')" +
 					"} else { return target[property] }" +
 					"}})";
 			} else {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -88,7 +88,16 @@ module.exports = function(content, map) {
 
 		var exportJs = compileExports(result, importItemMatcher.bind(this), camelCaseKeys);
 		if (exportJs) {
-			exportJs = "exports.locals = " + exportJs + ";";
+			if (query.cssModuleDevWarnings) {
+				exportJs = "exports.locals = new Proxy(" + exportJs + "," +
+					"{ get(target, property) { " +
+					"if (typeof target[property] !== 'string' && property !== '__esModule') {" +
+					"console.warn(`Attempted to access non-existent className '${property} on CSS module'`)" +
+					"} else { return target[property] }" +
+					"}})";
+			} else {
+				exportJs = "exports.locals = " + exportJs + ";"
+			}
 		}
 
 		var moduleJs;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
A new query param is added to the loader (`cssModuleDevWarnings`) that can be used in conjunction with CSS modules. At runtime, this will emit a `console.warn` anytime a non-existent class name is accessed on the CSS module.

**Did you add tests for your changes?**
Not yet. Happy to add them, just wanted to check if you'd be willing to accept this type of change before investing the time to write tests.

**If relevant, did you update the README?**
Yes

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
It's been too easy to mistype a property name when assigning a `className` property in React. At runtime, if `className` has been assigned to `undefined`, the element in DevTools will just show as having no classname at all. This is a helpful hint to warn you in development when you've typoed, similar to the types of dev warnings that React gives you.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Should not

**Other information**
This feature requires that the user have ES2015 proxy support in their browser, so it's super important this never makes it into a user's production code (also because proxies are slow). Looking for any input on how we can make this more obvious besides just docs (maybe a scarier query param name?)

**Example**
![image](https://cloud.githubusercontent.com/assets/5233399/23052227/58976452-f495-11e6-9fe8-3c2e28cec58c.png)
