### PR TITLE
fix: incorrect handling of non-mutated class names

### DIFF
--- a/lib/compile-exports.js
+++ b/lib/compile-exports.js
@@ -17,21 +17,32 @@ module.exports = function compileExports(result, importItemMatcher, camelCaseKey
     function addEntry(k) {
       res.push("\t" + JSON.stringify(k) + ": " + valueAsString);
     }
-    if (camelCaseKeys !== 'only' && camelCaseKeys !== 'dashesOnly') {
-      addEntry(key);
-    }
 
     var targetKey;
-    if (camelCaseKeys === true || camelCaseKeys === 'only') {
-      targetKey = camelCase(key);
-      if (targetKey !== key) {
-        addEntry(targetKey);
-      }
-    } else if (camelCaseKeys === 'dashes' || camelCaseKeys === 'dashesOnly') {
-      targetKey = dashesCamelCase(key);
-      if (targetKey !== key) {
-        addEntry(targetKey);
-      }
+    switch(camelCaseKeys) {
+      case true:
+        addEntry(key);
+        targetKey = camelCase(key);
+        if (targetKey !== key) {
+          addEntry(targetKey);
+        }
+        break;
+      case 'dashes':
+        addEntry(key);
+        targetKey = dashesCamelCase(key);
+        if (targetKey !== key) {
+          addEntry(targetKey);
+        }
+        break;
+      case 'only':
+        addEntry(camelCase(key));
+        break;
+      case 'dashesOnly':
+        addEntry(dashesCamelCase(key));
+        break;
+      default:
+        addEntry(key);
+        break;
     }
     return res;
   }, []).join(",\n");

--- a/test/camelCaseTest.js
+++ b/test/camelCaseTest.js
@@ -5,6 +5,7 @@ var testRaw = require("./helpers").testRaw;
 
 describe("camelCase", function() {
 	var css = ".btn-info_is-disabled { color: blue; }";
+	var mixedCss = ".btn-info_is-disabled { color: blue; } .simple { color: red; }";
 	var exports = {
 		with: [
 			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; }", ""]
@@ -16,24 +17,24 @@ describe("camelCase", function() {
 			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; }", ""]
 		],
 		withoutOnly: [
-			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; }", ""]
+			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; } .KKtodWG-IuEaequFjAsoJ { color: red; }", ""]
 		],
 		dashesOnly: [
-			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; }", ""]
+			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; } .KKtodWG-IuEaequFjAsoJ { color: red; }", ""]
 		]
 	};
 	exports.with.locals = {'btn-info_is-disabled': '_1L-rnCOXCE_7H94L5XT4uB'};
 	exports.without.locals = {btnInfoIsDisabled: '_1L-rnCOXCE_7H94L5XT4uB', 'btn-info_is-disabled': '_1L-rnCOXCE_7H94L5XT4uB'};
 	exports.dashes.locals = {btnInfo_isDisabled: '_1L-rnCOXCE_7H94L5XT4uB', 'btn-info_is-disabled': '_1L-rnCOXCE_7H94L5XT4uB'};
-	exports.withoutOnly.locals = {btnInfoIsDisabled: '_1L-rnCOXCE_7H94L5XT4uB'};
-	exports.dashesOnly.locals = {btnInfo_isDisabled: '_1L-rnCOXCE_7H94L5XT4uB'};
+	exports.withoutOnly.locals = {btnInfoIsDisabled: '_1L-rnCOXCE_7H94L5XT4uB', simple: 'KKtodWG-IuEaequFjAsoJ'};
+	exports.dashesOnly.locals = {btnInfo_isDisabled: '_1L-rnCOXCE_7H94L5XT4uB', simple: 'KKtodWG-IuEaequFjAsoJ'};
 	test("with", css, exports.with, "?modules");
 	test("without", css, exports.without, "?modules&camelCase");
 	test("dashes", css, exports.dashes, "?modules&camelCase=dashes");
 	// Remove this option in v1.0.0 and make the removal of the original classname the default behaviour. See #440.
-	test("withoutOnly", css, exports.withoutOnly, "?modules&camelCase=only");
+	test("withoutOnly", mixedCss, exports.withoutOnly, "?modules&camelCase=only");
 	// Remove this option in v1.0.0 and make the removal of the original classname the default behaviour. See #440.
-	test("dashesOnly", css, exports.dashesOnly, "?modules&camelCase=dashesOnly");
+	test("dashesOnly", mixedCss, exports.dashesOnly, "?modules&camelCase=dashesOnly");
 
 	testRaw("withoutRaw", '.a {}', 'exports.locals = {\n\t"a": "_1buUQJccBRS2-2i27LCoDf"\n};', "?modules&camelCase");
 	testRaw("dashesRaw", '.a {}', 'exports.locals = {\n\t"a": "_1buUQJccBRS2-2i27LCoDf"\n};', "?modules&camelCase=dashes");


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
yes

**If relevant, did you update the README?**
n/a

**Summary**

When converting a class name without dashes, the newly introduced `'only'` and `'dashesOnly'` settings for the `camelCase` option would only ever add the class name to locals if it was different to the standard class name. Any class w/o dash would therefore not be added to the locals at all.

**Does this PR introduce a breaking change?**
No

**Other information**
Introduced in #445 - released in `0.27.0`