### PR TITLE
added localByDefault option to allow you to override default behavior…

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ To be compatible with existing css files (if not in CSS Module mode):
 |:--:|:-----:|:----------|
 |**`root`**|`/`|Path to resolve URLs, URLs starting with `/` will not be translated|
 |**`modules`**|`false`|Enable/Disable CSS Modules|
+|**`localByDefault`**|`true`|treat unmarked selectors as :local|
 |**`import`** |`true`| Enable/Disable @import handling|
 |**`url`**|`true`| Enable/Disable `url()` handling|
 |**`minimize`**|`false`|Enable/Disable minification|
@@ -232,6 +233,12 @@ Note: For prerendering with extract-text-webpack-plugin you should use `css-load
 The query parameter `modules` enables the **CSS Modules** spec.
 
 This enables local scoped CSS by default. (You can switch it off with `:global(...)` or `:global` for selectors and/or rules.)
+
+### :local by default
+
+The query parameter `localByDefault` allows you to override the _"locals by default when using `modules: true`"_ behavior'.
+
+For selectors that have not been marked using :local or :global - this will allow you to decide which should be default. This will help for projects that are being ported from non css modules usage to using css modules.
 
 ### CSS Composing
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -15,6 +15,9 @@ module.exports = function(content, map) {
 	var query = loaderUtils.getOptions(this) || {};
 	var root = query.root;
 	var moduleMode = query.modules || query.module;
+  var localByDefault = typeof query.localByDefault !== 'undefined'
+    ? query.localByDefault
+    : true;
 	var camelCaseKeys = query.camelCase || query.camelcase;
 	var resolve = createResolver(query.alias);
 
@@ -23,7 +26,7 @@ module.exports = function(content, map) {
 	}
 
 	processCss(content, map, {
-		mode: moduleMode ? "local" : "global",
+		mode: moduleMode && localByDefault ? "local" : "global",
 		from: loaderUtils.getRemainingRequest(this),
 		to: loaderUtils.getCurrentRequest(this),
 		query: query,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -136,6 +136,16 @@ exports.testLocals = function testLocals(name, input, result, query, modules) {
 	});
 };
 
+exports.testLocal = function testLocal(name, input, result, localsResult, query, modules) {
+	result.locals = localsResult;
+	exports.test(name, input, result, query, modules);
+};
+
+exports.testLocalMinimize = function testLocalMinimize(name, input, result, localsResult, query, modules) {
+	result.locals = localsResult;
+	exports.testMinimize(name, input, result, query, modules);
+};
+
 exports.testSingleItem = function testSingleItem(name, input, result, query, modules) {
 	it(name, function(done) {
 		runLoader(cssLoader, input, undefined, {

--- a/test/localByDefaultTest.js
+++ b/test/localByDefaultTest.js
@@ -1,0 +1,23 @@
+/*globals describe */
+
+var test = require("./helpers").test;
+var testLocal = require("./helpers").testLocal;
+
+describe("localByDefault", function() {
+  test("should not impact when not modules unset", ".myclass { color: green; }", [
+    [1, ".myclass { color: green; }", ""]
+  ], '?localByDefault');
+  testLocal("modules true should use :local by default", ".myclass { color: green; }", [
+    [1, ".__2NVVs { color: green; }", ""],
+  ], {
+    myclass: "__2NVVs"
+  }, "?modules&localIdentName=__[hash:base64:5]");
+  testLocal("should use :local for localByDefault true", ".myclass { color: green; }", [
+    [1, ".__2NVVs { color: green; }", ""],
+  ], {
+    myclass: "__2NVVs"
+  }, "?modules&localIdentName=__[hash:base64:5]&localByDefault");
+  test("should use :global for localByDefault false", ".myclass { color: green; }", [
+    [1, ".myclass { color: green; }", ""],
+  ], "?modules&localIdentName=__[hash:base64:5]&localByDefault=false");
+});

--- a/test/localTest.js
+++ b/test/localTest.js
@@ -1,17 +1,7 @@
 /*globals describe */
 
-var test = require("./helpers").test;
-var testMinimize = require("./helpers").testMinimize;
-
-function testLocal(name, input, result, localsResult, query, modules) {
-	result.locals = localsResult;
-	test(name, input, result, query, modules);
-}
-
-function testLocalMinimize(name, input, result, localsResult, query, modules) {
-	result.locals = localsResult;
-	testMinimize(name, input, result, query, modules);
-}
+var testLocal = require("./helpers").testLocal;
+var testLocalMinimize = require("./helpers").testLocalMinimize;
 
 describe("local", function() {
 	testLocal("locals-format", ":local(.test) { background: red; }", [


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**Did you add tests for your changes?**
Yes.

**If relevant, did you update the README?**
Yes.

**Summary**
The default behavior when using `modules: true` uses `:local` mode by default. This option allows you to override that behavior. This is useful for porting projects which weren't previously using CSS Modules to start using it.

**Does this PR introduce a breaking change?**
No.

**Other information**
N/A
