### PR TITLE
Only load cssnano if we're going to use it.

### DIFF
--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -13,7 +13,6 @@ var localByDefault = require("postcss-modules-local-by-default");
 var extractImports = require("postcss-modules-extract-imports");
 var modulesScope = require("postcss-modules-scope");
 var modulesValues = require("postcss-modules-values");
-var cssnano = require("cssnano");
 
 var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 	return function(css) {
@@ -141,7 +140,7 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 	var minimize = typeof forceMinimize !== "undefined" ? !!forceMinimize : options.minimize;
 
 	var customGetLocalIdent = query.getLocalIdent || getLocalIdent;
-	
+
 	var parserOptions = {
 		root: root,
 		mode: options.mode,
@@ -179,6 +178,7 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 	]);
 
 	if(minimize) {
+		var cssnano = require("cssnano");
 		var minimizeOptions = assign({}, query.minimize);
 		["zindex", "normalizeUrl", "discardUnused", "mergeIdents", "reduceIdents", "autoprefixer"].forEach(function(name) {
 			if(typeof minimizeOptions[name] === "undefined")


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
N/A

**If relevant, did you update the README?**
N/A

**Summary**

css-loader relies on cssnano, which relies on postcss-filter-plugins, which relies on uniqid, which relies on macaddress.

[macaddress](https://github.com/scravy/node-macaddress) has a global leak in v0.2.8.  They accidentally create a [global variable named `addresses`](https://github.com/scravy/node-macaddress/blob/0.2.8/index.js#L34).  This is a problem, because if you use this pacakge, and you supply `--check-leaks` to mocha, mocha will spaz out about the fact that there's this extra global variable.

The good news is, this is fixed in macaddress#master.  The bad news is, they haven't [published the fix for 9 months](https://github.com/scravy/node-macaddress/issues/7).

[uniqid](https://github.com/adamhalasz/uniqid) relies on macaddress (and, obnoxiously, [calls it at top-level-scope](https://github.com/adamhalasz/uniqid/blob/770e826b0b6e1f34287b5a36a746031417f9acb0/index.js#L15)), so I'd like to harass them into switching from macaddress to some other package, but they were [made aware of this issue six months ago](https://github.com/adamhalasz/uniqid/issues/8), and they still haven't done anything.

I've raised an issue with [postcss-filter-plugins](https://github.com/postcss/postcss-filter-plugins/issues/16), but they had [a PR that would have fixed this](https://github.com/postcss/postcss-filter-plugins/pull/15) and the closed it without merging it because they're going to deprecate postcss-filter-plugins and remove it from cssnano entirely.

So, this is a slightly awful fix which makes it so we don't even `require` cssnano in css-loader unless we plan to do some minimization.  Since that's the default, it should fix this problem for most people.  Note that node will cache the required cssnano, so if you are using minimization, this won't cause any noticeable performance problems (and I suppose it will very marginally speed things up for people who aren't doing minimization).

**Does this PR introduce a breaking change?**
No.
