### PR TITLE
Fix package.json's engines.node field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "css loader module for webpack",
   "engines": {
-    "node": ">=0.12.0 || >=4.3.0 <5.0.0 || >=5.10"
+    "node": ">=4.3 <5 || >=5.10"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Bugfix.

**Did you add tests for your changes?**

N/A

**If relevant, did you update the README?**

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

`package.json`'s engines `node` field used to be defined as `">=0.12.0 || >=4.3.0 <5.0.0 || >=5.10"`. This range was erroneously equivalent to just `>=0.12`. Now only version betwee `4.3 & 5` or `>=5.10` are picked up by the range.

Fixes #482

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

That depends. Users of Node 0.12 & npm 2 combo will get an error during the installation of this package after this PR is merged. Whether that's considered a breaking change I'll leave for maintainers to decide.

**Other information**
