### PR TITLE
feat: add externals support for CSS imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If there are SourceMaps, they will also be included in the result string.
 |**`sourceMap`**|`{Boolean}`|`false`|Enable/Disable Sourcemaps|
 |**`camelCase`**|`{Boolean\|String}`|`false`|Export Classnames in CamelCase|
 |**`importLoaders`**|`{Number}`|`0`|Number of loaders applied before CSS loader|
-|**`externals`**|`{}`|Import from globally available external object|
+|**`externals`**|`{Object}`|`{}`|Import from globally available external object|
 
 ### `root`
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If there are SourceMaps, they will also be included in the result string.
 |**`sourceMap`**|`{Boolean}`|`false`|Enable/Disable Sourcemaps|
 |**`camelCase`**|`{Boolean\|String}`|`false`|Export Classnames in CamelCase|
 |**`importLoaders`**|`{Number}`|`0`|Number of loaders applied before CSS loader|
+|**`externals`**|`{}`|Import from globally available external object|
 
 ### `root`
 
@@ -411,6 +412,30 @@ The query parameter `importLoaders` allows to configure how many loaders before 
 ```
 
 This may change in the future, when the module system (i. e. webpack) supports loader matching by origin.
+
+### `externals`
+
+Much like Webpack's core [externals](https://webpack.js.org/configuration/externals/) feature:
+
+> The externals configuration option provides a way of excluding dependencies from the output bundles. Instead, the created bundle relies on that dependency to be present in the consumer's environment.
+
+**webpack.config.js**
+```js
+{
+  test: /\.css$/,
+  use: [
+    'style-loader',
+    {
+      loader: 'css-loader',
+      options: {
+        externals: {
+          'my-package': 'MyPackage'
+        }
+      }
+    }
+  ]
+}
+```
 
 <h2 align="center">Examples</h2>
 

--- a/lib/getExternals.js
+++ b/lib/getExternals.js
@@ -1,0 +1,20 @@
+module.exports = function (loaderContext, query) {
+	var givenExternals = query.externals || (loaderContext.externals || {});
+	var externals = {};
+
+	if (Array.isArray(givenExternals)) {
+		givenExternals.forEach(function (external) {
+			if (typeof external === 'object') {
+				externals = Object.assign({}, externals, external);
+			}
+		});
+	} else {
+		externals = givenExternals;
+	}
+
+	if (typeof externals === 'string') {
+		externals = JSON.parse(externals);
+	}
+
+	return externals;
+}

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,10 +4,23 @@
 */
 var loaderUtils = require("loader-utils");
 var processCss = require("./processCss");
+var getExternals = require("./getExternals");
 var getImportPrefix = require("./getImportPrefix");
 var compileExports = require("./compile-exports");
 var createResolver = require("./createResolver");
 
+function findExternalFromImportUrl(importUrl, externals) {
+	var externalsKeys = Object.keys(externals);
+	var key = externalsKeys.find(function (externalsKey) {
+		return importUrl.endsWith(externalsKey);
+	});
+
+	if (key) {
+		return externals[key];
+	}
+
+	return false;
+}
 
 module.exports = function(content, map) {
 	if(this.cacheable) this.cacheable();
@@ -18,36 +31,7 @@ module.exports = function(content, map) {
 	var camelCaseKeys = query.camelCase || query.camelcase;
 	var sourceMap = query.sourceMap || false;
 	var resolve = createResolver(query.alias);
-
-	var givenExternals = query.externals || (this.externals || {});
-	var externals = {};
-	if (Array.isArray(givenExternals)) {
-		givenExternals.forEach(function (external) {
-			if (typeof external === 'object') {
-				externals = Object.assign({}, externals, external);
-			}
-		});
-	} else {
-		externals = givenExternals;
-	}
-
-	if (typeof externals === 'string') {
-		externals = JSON.parse(externals);
-	}
-
-	var externalsKeys = Object.keys(externals);
-
-	function findExternalFromImportUrl(importUrl) {
-		var key = externalsKeys.find(function (externalsKey) {
-			return importUrl.endsWith(externalsKey);
-		});
-
-		if (key) {
-			return externals[key];
-		}
-
-		return false;
-	}
+	var externals = getExternals(this, query);
 
 	if(sourceMap) {
 		if (map && typeof map !== "string") {
@@ -90,7 +74,7 @@ module.exports = function(content, map) {
 			} else {
 				var importUrl = importUrlPrefix + imp.url;
 
-				var external = findExternalFromImportUrl(importUrl);
+				var external = findExternalFromImportUrl(importUrl, externals);
 				if (external === false) {
 					return "exports.i(require(" + loaderUtils.stringifyRequest(this, importUrl) + "), " + JSON.stringify(imp.mediaQuery) + ");";
 				}
@@ -105,7 +89,7 @@ module.exports = function(content, map) {
 			var importItem = result.importItems[idx];
 			var importUrl = importUrlPrefix + importItem.url;
 
-			var external = findExternalFromImportUrl(importUrl);
+			var external = findExternalFromImportUrl(importUrl, externals);
 			if (external === false) {
 				return "\" + require(" + loaderUtils.stringifyRequest(this, importUrl) + ").locals" +
 				"[" + JSON.stringify(importItem.export) + "] + \"";

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,6 +1,6 @@
 /*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Tobias Koppers @sokra
+  MIT License http://www.opensource.org/licenses/mit-license.php
+  Author Tobias Koppers @sokra
 */
 var loaderUtils = require("loader-utils");
 var processCss = require("./processCss");
@@ -10,114 +10,153 @@ var createResolver = require("./createResolver");
 
 
 module.exports = function(content, map) {
-	if(this.cacheable) this.cacheable();
-	var callback = this.async();
-	var query = loaderUtils.getOptions(this) || {};
-	var root = query.root;
-	var moduleMode = query.modules || query.module;
-	var camelCaseKeys = query.camelCase || query.camelcase;
-	var resolve = createResolver(query.alias);
+  if(this.cacheable) this.cacheable();
+  var callback = this.async();
+  var query = loaderUtils.getOptions(this) || {};
+  var root = query.root;
+  var moduleMode = query.modules || query.module;
+  var camelCaseKeys = query.camelCase || query.camelcase;
+  var resolve = createResolver(query.alias);
 
-	if(map !== null && typeof map !== "string") {
-		map = JSON.stringify(map);
-	}
+  var givenExternals = query.externals || {};
+  var externals = {};
+  if (Array.isArray(givenExternals)) {
+    givenExternals.forEach(function (external) {
+      if (typeof external === 'object') {
+        externals = Object.assign({}, externals, external);
+      }
+    });
+  } else {
+    externals = givenExternals;
+  }
 
-	processCss(content, map, {
-		mode: moduleMode ? "local" : "global",
-		from: loaderUtils.getRemainingRequest(this),
-		to: loaderUtils.getCurrentRequest(this),
-		query: query,
-		minimize: this.minimize,
-		loaderContext: this
-	}, function(err, result) {
-		if(err) return callback(err);
+  var externalsKeys = Object.keys(externals);
 
-		var cssAsString = JSON.stringify(result.source);
+  function findExternalFromImportUrl(importUrl) {
+    var key = externalsKeys.find(function (externalsKey) {
+      return importUrl.endsWith(externalsKey);
+    });
 
-		// for importing CSS
-		var importUrlPrefix = getImportPrefix(this, query);
+    if (key) {
+      return externals[key];
+    }
 
-		var alreadyImported = {};
-		var importJs = result.importItems.filter(function(imp) {
-			if(!imp.mediaQuery) {
-				if(alreadyImported[imp.url])
-					return false;
-				alreadyImported[imp.url] = true;
-			}
-			return true;
-		}).map(function(imp) {
-			if(!loaderUtils.isUrlRequest(imp.url, root)) {
-				return "exports.push([module.id, " +
-					JSON.stringify("@import url(" + imp.url + ");") + ", " +
-					JSON.stringify(imp.mediaQuery) + "]);";
-			} else {
-				var importUrl = importUrlPrefix + imp.url;
-				return "exports.i(require(" + loaderUtils.stringifyRequest(this, importUrl) + "), " + JSON.stringify(imp.mediaQuery) + ");";
-			}
-		}, this).join("\n");
+    return false;
+  }
 
-		function importItemMatcher(item) {
-			var match = result.importItemRegExp.exec(item);
-			var idx = +match[1];
-			var importItem = result.importItems[idx];
-			var importUrl = importUrlPrefix + importItem.url;
-			return "\" + require(" + loaderUtils.stringifyRequest(this, importUrl) + ").locals" +
-				"[" + JSON.stringify(importItem.export) + "] + \"";
-		}
+  if(map !== null && typeof map !== "string") {
+    map = JSON.stringify(map);
+  }
 
-		cssAsString = cssAsString.replace(result.importItemRegExpG, importItemMatcher.bind(this));
-		if(query.url !== false) {
-			cssAsString = cssAsString.replace(result.urlItemRegExpG, function(item) {
-				var match = result.urlItemRegExp.exec(item);
-				var idx = +match[1];
-				var urlItem = result.urlItems[idx];
-				var url = resolve(urlItem.url);
-				idx = url.indexOf("?#");
-				if(idx < 0) idx = url.indexOf("#");
-				var urlRequest;
-				if(idx > 0) { // idx === 0 is catched by isUrlRequest
-					// in cases like url('webfont.eot?#iefix')
-					urlRequest = url.substr(0, idx);
-					return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"" +
-							url.substr(idx);
-				}
-				urlRequest = url;
-				return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"";
-			}.bind(this));
-		}
+  processCss(content, map, {
+    mode: moduleMode ? "local" : "global",
+    from: loaderUtils.getRemainingRequest(this),
+    to: loaderUtils.getCurrentRequest(this),
+    query: query,
+    minimize: this.minimize,
+    loaderContext: this
+  }, function(err, result) {
+    if(err) return callback(err);
+
+    var cssAsString = JSON.stringify(result.source);
+
+    // for importing CSS
+    var importUrlPrefix = getImportPrefix(this, query);
+
+    var alreadyImported = {};
+    var importJs = result.importItems.filter(function(imp) {
+      if(!imp.mediaQuery) {
+        if(alreadyImported[imp.url])
+          return false;
+        alreadyImported[imp.url] = true;
+      }
+      return true;
+    }).map(function(imp) {
+      if(!loaderUtils.isUrlRequest(imp.url, root)) {
+        return "exports.push([module.id, " +
+          JSON.stringify("@import url(" + imp.url + ");") + ", " +
+          JSON.stringify(imp.mediaQuery) + "]);";
+      } else {
+        var importUrl = importUrlPrefix + imp.url;
+
+        var external = findExternalFromImportUrl(importUrl);
+        if (external === false) {
+          return "exports.i(require(" + loaderUtils.stringifyRequest(this, importUrl) + "), " + JSON.stringify(imp.mediaQuery) + ");";
+        }
+
+        return "exports.i(" + external + ", " + JSON.stringify(imp.mediaQuery) + ");";
+      }
+    }, this).join("\n");
+
+    function importItemMatcher(item) {
+      var match = result.importItemRegExp.exec(item);
+      var idx = +match[1];
+      var importItem = result.importItems[idx];
+      var importUrl = importUrlPrefix + importItem.url;
+
+      var external = findExternalFromImportUrl(importUrl);
+      if (external === false) {
+        return "\" + require(" + loaderUtils.stringifyRequest(this, importUrl) + ").locals" +
+        "[" + JSON.stringify(importItem.export) + "] + \"";
+      }
+
+      return "\" + " + external + "" +
+        "[" + JSON.stringify(importItem.export) + "] + \"";
+    }
+
+    cssAsString = cssAsString.replace(result.importItemRegExpG, importItemMatcher.bind(this));
+    if(query.url !== false) {
+      cssAsString = cssAsString.replace(result.urlItemRegExpG, function(item) {
+        var match = result.urlItemRegExp.exec(item);
+        var idx = +match[1];
+        var urlItem = result.urlItems[idx];
+        var url = resolve(urlItem.url);
+        idx = url.indexOf("?#");
+        if(idx < 0) idx = url.indexOf("#");
+        var urlRequest;
+        if(idx > 0) { // idx === 0 is catched by isUrlRequest
+          // in cases like url('webfont.eot?#iefix')
+          urlRequest = url.substr(0, idx);
+          return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"" +
+              url.substr(idx);
+        }
+        urlRequest = url;
+        return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"";
+      }.bind(this));
+    }
 
 
-		var exportJs = compileExports(result, importItemMatcher.bind(this), camelCaseKeys);
-		if (exportJs) {
-			exportJs = "exports.locals = " + exportJs + ";";
-		}
+    var exportJs = compileExports(result, importItemMatcher.bind(this), camelCaseKeys);
+    if (exportJs) {
+      exportJs = "exports.locals = " + exportJs + ";";
+    }
 
-		var moduleJs;
-		if(query.sourceMap && result.map) {
-			// add a SourceMap
-			map = result.map;
-			if(map.sources) {
-				map.sources = map.sources.map(function(source) {
-					return source.split("!").pop();
-				}, this);
-				map.sourceRoot = "";
-			}
-			map.file = map.file.split("!").pop();
-			map = JSON.stringify(map);
-			moduleJs = "exports.push([module.id, " + cssAsString + ", \"\", " + map + "]);";
-		} else {
-			moduleJs = "exports.push([module.id, " + cssAsString + ", \"\"]);";
-		}
+    var moduleJs;
+    if(query.sourceMap && result.map) {
+      // add a SourceMap
+      map = result.map;
+      if(map.sources) {
+        map.sources = map.sources.map(function(source) {
+          return source.split("!").pop();
+        }, this);
+        map.sourceRoot = "";
+      }
+      map.file = map.file.split("!").pop();
+      map = JSON.stringify(map);
+      moduleJs = "exports.push([module.id, " + cssAsString + ", \"\", " + map + "]);";
+    } else {
+      moduleJs = "exports.push([module.id, " + cssAsString + ", \"\"]);";
+    }
 
-		// embed runtime
-		callback(null, "exports = module.exports = require(" +
-			loaderUtils.stringifyRequest(this, require.resolve("./css-base.js")) +
-			")(" + query.sourceMap + ");\n" +
-			"// imports\n" +
-			importJs + "\n\n" +
-			"// module\n" +
-			moduleJs + "\n\n" +
-			"// exports\n" +
-			exportJs);
-	}.bind(this));
+    // embed runtime
+    callback(null, "exports = module.exports = require(" +
+      loaderUtils.stringifyRequest(this, require.resolve("./css-base.js")) +
+      ")(" + query.sourceMap + ");\n" +
+      "// imports\n" +
+      importJs + "\n\n" +
+      "// module\n" +
+      moduleJs + "\n\n" +
+      "// exports\n" +
+      exportJs);
+  }.bind(this));
 };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -18,7 +18,7 @@ module.exports = function(content, map) {
 	var camelCaseKeys = query.camelCase || query.camelcase;
 	var resolve = createResolver(query.alias);
 
-	var givenExternals = query.externals || {};
+	var givenExternals = query.externals || (this.externals || {});
 	var externals = {};
 	if (Array.isArray(givenExternals)) {
 		givenExternals.forEach(function (external) {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,6 +1,6 @@
 /*
-  MIT License http://www.opensource.org/licenses/mit-license.php
-  Author Tobias Koppers @sokra
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
 */
 var loaderUtils = require("loader-utils");
 var processCss = require("./processCss");
@@ -10,153 +10,153 @@ var createResolver = require("./createResolver");
 
 
 module.exports = function(content, map) {
-  if(this.cacheable) this.cacheable();
-  var callback = this.async();
-  var query = loaderUtils.getOptions(this) || {};
-  var root = query.root;
-  var moduleMode = query.modules || query.module;
-  var camelCaseKeys = query.camelCase || query.camelcase;
-  var resolve = createResolver(query.alias);
+	if(this.cacheable) this.cacheable();
+	var callback = this.async();
+	var query = loaderUtils.getOptions(this) || {};
+	var root = query.root;
+	var moduleMode = query.modules || query.module;
+	var camelCaseKeys = query.camelCase || query.camelcase;
+	var resolve = createResolver(query.alias);
 
-  var givenExternals = query.externals || {};
-  var externals = {};
-  if (Array.isArray(givenExternals)) {
-    givenExternals.forEach(function (external) {
-      if (typeof external === 'object') {
-        externals = Object.assign({}, externals, external);
-      }
-    });
-  } else {
-    externals = givenExternals;
-  }
+	var givenExternals = query.externals || {};
+	var externals = {};
+	if (Array.isArray(givenExternals)) {
+		givenExternals.forEach(function (external) {
+			if (typeof external === 'object') {
+				externals = Object.assign({}, externals, external);
+			}
+		});
+	} else {
+		externals = givenExternals;
+	}
 
-  var externalsKeys = Object.keys(externals);
+	var externalsKeys = Object.keys(externals);
 
-  function findExternalFromImportUrl(importUrl) {
-    var key = externalsKeys.find(function (externalsKey) {
-      return importUrl.endsWith(externalsKey);
-    });
+	function findExternalFromImportUrl(importUrl) {
+		var key = externalsKeys.find(function (externalsKey) {
+			return importUrl.endsWith(externalsKey);
+		});
 
-    if (key) {
-      return externals[key];
-    }
+		if (key) {
+			return externals[key];
+		}
 
-    return false;
-  }
+		return false;
+	}
 
-  if(map !== null && typeof map !== "string") {
-    map = JSON.stringify(map);
-  }
+	if(map !== null && typeof map !== "string") {
+		map = JSON.stringify(map);
+	}
 
-  processCss(content, map, {
-    mode: moduleMode ? "local" : "global",
-    from: loaderUtils.getRemainingRequest(this),
-    to: loaderUtils.getCurrentRequest(this),
-    query: query,
-    minimize: this.minimize,
-    loaderContext: this
-  }, function(err, result) {
-    if(err) return callback(err);
+	processCss(content, map, {
+		mode: moduleMode ? "local" : "global",
+		from: loaderUtils.getRemainingRequest(this),
+		to: loaderUtils.getCurrentRequest(this),
+		query: query,
+		minimize: this.minimize,
+		loaderContext: this
+	}, function(err, result) {
+		if(err) return callback(err);
 
-    var cssAsString = JSON.stringify(result.source);
+		var cssAsString = JSON.stringify(result.source);
 
-    // for importing CSS
-    var importUrlPrefix = getImportPrefix(this, query);
+		// for importing CSS
+		var importUrlPrefix = getImportPrefix(this, query);
 
-    var alreadyImported = {};
-    var importJs = result.importItems.filter(function(imp) {
-      if(!imp.mediaQuery) {
-        if(alreadyImported[imp.url])
-          return false;
-        alreadyImported[imp.url] = true;
-      }
-      return true;
-    }).map(function(imp) {
-      if(!loaderUtils.isUrlRequest(imp.url, root)) {
-        return "exports.push([module.id, " +
-          JSON.stringify("@import url(" + imp.url + ");") + ", " +
-          JSON.stringify(imp.mediaQuery) + "]);";
-      } else {
-        var importUrl = importUrlPrefix + imp.url;
+		var alreadyImported = {};
+		var importJs = result.importItems.filter(function(imp) {
+			if(!imp.mediaQuery) {
+				if(alreadyImported[imp.url])
+					return false;
+				alreadyImported[imp.url] = true;
+			}
+			return true;
+		}).map(function(imp) {
+			if(!loaderUtils.isUrlRequest(imp.url, root)) {
+				return "exports.push([module.id, " +
+					JSON.stringify("@import url(" + imp.url + ");") + ", " +
+					JSON.stringify(imp.mediaQuery) + "]);";
+			} else {
+				var importUrl = importUrlPrefix + imp.url;
 
-        var external = findExternalFromImportUrl(importUrl);
-        if (external === false) {
-          return "exports.i(require(" + loaderUtils.stringifyRequest(this, importUrl) + "), " + JSON.stringify(imp.mediaQuery) + ");";
-        }
+				var external = findExternalFromImportUrl(importUrl);
+				if (external === false) {
+					return "exports.i(require(" + loaderUtils.stringifyRequest(this, importUrl) + "), " + JSON.stringify(imp.mediaQuery) + ");";
+				}
 
-        return "exports.i(" + external + ", " + JSON.stringify(imp.mediaQuery) + ");";
-      }
-    }, this).join("\n");
+				return "exports.i(" + external + ", " + JSON.stringify(imp.mediaQuery) + ");";
+			}
+		}, this).join("\n");
 
-    function importItemMatcher(item) {
-      var match = result.importItemRegExp.exec(item);
-      var idx = +match[1];
-      var importItem = result.importItems[idx];
-      var importUrl = importUrlPrefix + importItem.url;
+		function importItemMatcher(item) {
+			var match = result.importItemRegExp.exec(item);
+			var idx = +match[1];
+			var importItem = result.importItems[idx];
+			var importUrl = importUrlPrefix + importItem.url;
 
-      var external = findExternalFromImportUrl(importUrl);
-      if (external === false) {
-        return "\" + require(" + loaderUtils.stringifyRequest(this, importUrl) + ").locals" +
-        "[" + JSON.stringify(importItem.export) + "] + \"";
-      }
+			var external = findExternalFromImportUrl(importUrl);
+			if (external === false) {
+				return "\" + require(" + loaderUtils.stringifyRequest(this, importUrl) + ").locals" +
+				"[" + JSON.stringify(importItem.export) + "] + \"";
+			}
 
-      return "\" + " + external + "" +
-        "[" + JSON.stringify(importItem.export) + "] + \"";
-    }
+			return "\" + " + external + "" +
+				"[" + JSON.stringify(importItem.export) + "] + \"";
+		}
 
-    cssAsString = cssAsString.replace(result.importItemRegExpG, importItemMatcher.bind(this));
-    if(query.url !== false) {
-      cssAsString = cssAsString.replace(result.urlItemRegExpG, function(item) {
-        var match = result.urlItemRegExp.exec(item);
-        var idx = +match[1];
-        var urlItem = result.urlItems[idx];
-        var url = resolve(urlItem.url);
-        idx = url.indexOf("?#");
-        if(idx < 0) idx = url.indexOf("#");
-        var urlRequest;
-        if(idx > 0) { // idx === 0 is catched by isUrlRequest
-          // in cases like url('webfont.eot?#iefix')
-          urlRequest = url.substr(0, idx);
-          return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"" +
-              url.substr(idx);
-        }
-        urlRequest = url;
-        return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"";
-      }.bind(this));
-    }
+		cssAsString = cssAsString.replace(result.importItemRegExpG, importItemMatcher.bind(this));
+		if(query.url !== false) {
+			cssAsString = cssAsString.replace(result.urlItemRegExpG, function(item) {
+				var match = result.urlItemRegExp.exec(item);
+				var idx = +match[1];
+				var urlItem = result.urlItems[idx];
+				var url = resolve(urlItem.url);
+				idx = url.indexOf("?#");
+				if(idx < 0) idx = url.indexOf("#");
+				var urlRequest;
+				if(idx > 0) { // idx === 0 is catched by isUrlRequest
+					// in cases like url('webfont.eot?#iefix')
+					urlRequest = url.substr(0, idx);
+					return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"" +
+							url.substr(idx);
+				}
+				urlRequest = url;
+				return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"";
+			}.bind(this));
+		}
 
 
-    var exportJs = compileExports(result, importItemMatcher.bind(this), camelCaseKeys);
-    if (exportJs) {
-      exportJs = "exports.locals = " + exportJs + ";";
-    }
+		var exportJs = compileExports(result, importItemMatcher.bind(this), camelCaseKeys);
+		if (exportJs) {
+			exportJs = "exports.locals = " + exportJs + ";";
+		}
 
-    var moduleJs;
-    if(query.sourceMap && result.map) {
-      // add a SourceMap
-      map = result.map;
-      if(map.sources) {
-        map.sources = map.sources.map(function(source) {
-          return source.split("!").pop();
-        }, this);
-        map.sourceRoot = "";
-      }
-      map.file = map.file.split("!").pop();
-      map = JSON.stringify(map);
-      moduleJs = "exports.push([module.id, " + cssAsString + ", \"\", " + map + "]);";
-    } else {
-      moduleJs = "exports.push([module.id, " + cssAsString + ", \"\"]);";
-    }
+		var moduleJs;
+		if(query.sourceMap && result.map) {
+			// add a SourceMap
+			map = result.map;
+			if(map.sources) {
+				map.sources = map.sources.map(function(source) {
+					return source.split("!").pop();
+				}, this);
+				map.sourceRoot = "";
+			}
+			map.file = map.file.split("!").pop();
+			map = JSON.stringify(map);
+			moduleJs = "exports.push([module.id, " + cssAsString + ", \"\", " + map + "]);";
+		} else {
+			moduleJs = "exports.push([module.id, " + cssAsString + ", \"\"]);";
+		}
 
-    // embed runtime
-    callback(null, "exports = module.exports = require(" +
-      loaderUtils.stringifyRequest(this, require.resolve("./css-base.js")) +
-      ")(" + query.sourceMap + ");\n" +
-      "// imports\n" +
-      importJs + "\n\n" +
-      "// module\n" +
-      moduleJs + "\n\n" +
-      "// exports\n" +
-      exportJs);
-  }.bind(this));
+		// embed runtime
+		callback(null, "exports = module.exports = require(" +
+			loaderUtils.stringifyRequest(this, require.resolve("./css-base.js")) +
+			")(" + query.sourceMap + ");\n" +
+			"// imports\n" +
+			importJs + "\n\n" +
+			"// module\n" +
+			moduleJs + "\n\n" +
+			"// exports\n" +
+			exportJs);
+	}.bind(this));
 };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -30,6 +30,10 @@ module.exports = function(content, map) {
 		externals = givenExternals;
 	}
 
+	if (typeof externals === 'string') {
+		externals = JSON.parse(externals);
+	}
+
 	var externalsKeys = Object.keys(externals);
 
 	function findExternalFromImportUrl(importUrl) {
@@ -124,7 +128,6 @@ module.exports = function(content, map) {
 				return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"";
 			}.bind(this));
 		}
-
 
 		var exportJs = compileExports(result, importItemMatcher.bind(this), camelCaseKeys);
 		if (exportJs) {

--- a/test/externalsTest.js
+++ b/test/externalsTest.js
@@ -1,0 +1,69 @@
+/*globals describe */
+
+var test = require("./helpers").test;
+
+function testLocal(name, input, result, localsResult, query, modules) {
+	result.locals = localsResult;
+	test(name, input, result, query, modules);
+}
+
+describe("externals", function() {
+	before(function () {
+		global.External = {
+			External: {
+				c2: "imported-c2",
+				c4: "imported-c4"
+			}
+		};
+	});
+
+	testLocal(
+		// name
+		"composes class from external module",
+
+		// input
+		[
+			":local(.c1) { composes: c2 from \"external\"; b: 1; }",
+			":local(.c3) { composes: c1; b: 3; }",
+			":local(.c5) { composes: c2 c4 from \"external\"; b: 5; }"
+		].join("\n"),
+
+		// result
+		[
+			[
+				2,
+				".test{c: d}",
+				""
+			],
+			[
+				1,
+				[
+					"._c1 { b: 1; }",
+					"._c3 { b: 3; }",
+					"._c5 { b: 5; }"
+				].join("\n"), ""]
+		],
+
+		// localsResult
+		{
+			c1: "_c1 imported-c2",
+			c3: "_c3 _c1 imported-c2",
+			c5: "_c5 imported-c2 imported-c4"
+		},
+
+		// query
+		{
+			localIdentName: '[name]__[local]___[hash:base64:5]',
+			externals: {
+				external: 'External'
+			}
+		},
+
+		// modules
+		{}
+	);
+
+	after(function () {
+		delete global.External;
+	})
+});

--- a/test/externalsTest.js
+++ b/test/externalsTest.js
@@ -1,4 +1,4 @@
-/*globals describe */
+/*globals describe, before, after */
 
 var test = require("./helpers").test;
 
@@ -10,10 +10,8 @@ function testLocal(name, input, result, localsResult, query, modules) {
 describe("externals", function() {
 	before(function () {
 		global.External = {
-			External: {
-				c2: "imported-c2",
-				c4: "imported-c4"
-			}
+			c2: "imported-c2",
+			c4: "imported-c4"
 		};
 	});
 
@@ -31,17 +29,13 @@ describe("externals", function() {
 		// result
 		[
 			[
-				2,
-				".test{c: d}",
-				""
-			],
-			[
 				1,
 				[
 					"._c1 { b: 1; }",
 					"._c3 { b: 3; }",
 					"._c5 { b: 5; }"
-				].join("\n"), ""]
+				].join("\n"), ""
+			]
 		],
 
 		// localsResult
@@ -52,12 +46,15 @@ describe("externals", function() {
 		},
 
 		// query
-		{
-			localIdentName: '[name]__[local]___[hash:base64:5]',
-			externals: {
-				external: 'External'
-			}
-		},
+		'?localIdentName=_[local]&externals={"external":"External"}',
+
+		// @TODO: test with query as an object too
+		// {
+		// 	localIdentName: '_[local]',
+		// 	externals: {
+		// 		external: 'External'
+		// 	}
+		// },
 
 		// modules
 		{}

--- a/test/externalsTest.js
+++ b/test/externalsTest.js
@@ -15,50 +15,53 @@ describe("externals", function() {
 		};
 	});
 
-	testLocal(
-		// name
-		"composes class from external module",
-
-		// input
-		[
-			":local(.c1) { composes: c2 from \"external\"; b: 1; }",
-			":local(.c3) { composes: c1; b: 3; }",
-			":local(.c5) { composes: c2 c4 from \"external\"; b: 5; }"
-		].join("\n"),
-
-		// result
-		[
-			[
-				1,
-				[
-					"._c1 { b: 1; }",
-					"._c3 { b: 3; }",
-					"._c5 { b: 5; }"
-				].join("\n"), ""
-			]
-		],
-
-		// localsResult
+	[
 		{
-			c1: "_c1 imported-c2",
-			c3: "_c3 _c1 imported-c2",
-			c5: "_c5 imported-c2 imported-c4"
+			name: "composes class from external module, with query string",
+			query: '?localIdentName=_[local]&externals={"external":"External"}',
 		},
+		{
+			name: "composes class from external module, with externals as an array",
+			query: '?{"localIdentName":"_[local]","externals":[{"external":"External"}]}',
+		}
+	].forEach(function (t) {
+		testLocal(
+			// name
+			t.name,
 
-		// query
-		'?localIdentName=_[local]&externals={"external":"External"}',
+			// input
+			[
+				":local(.c1) { composes: c2 from \"external\"; b: 1; }",
+				":local(.c3) { composes: c1; b: 3; }",
+				":local(.c5) { composes: c2 c4 from \"external\"; b: 5; }"
+			].join("\n"),
 
-		// @TODO: test with query as an object too
-		// {
-		// 	localIdentName: '_[local]',
-		// 	externals: {
-		// 		external: 'External'
-		// 	}
-		// },
+			// result
+			[
+				[
+					1,
+					[
+						"._c1 { b: 1; }",
+						"._c3 { b: 3; }",
+						"._c5 { b: 5; }"
+					].join("\n"), ""
+				]
+			],
 
-		// modules
-		{}
-	);
+			// localsResult
+			{
+				c1: "_c1 imported-c2",
+				c3: "_c3 _c1 imported-c2",
+				c5: "_c5 imported-c2 imported-c4"
+			},
+
+			// query
+			t.query,
+
+			// modules
+			{}
+		);
+	});
 
 	after(function () {
 		delete global.External;


### PR DESCRIPTION
## What kind of change does this PR introduce?

New feature via `externals` option in `css-loader`, much like Webpack's core externals feature.

## Did you add tests for your changes?

Yes.

## If relevant, did you update the README?

Yes.

## Summary

I opened an issue in `css-modules` repository for this first: https://github.com/css-modules/css-modules/issues/227

To summarise, I want a setup like this with [FrintJS](https://frint.js.org):

```html
<!-- vendors -->
<script src="lodash.js"></script>
<script src="react.js"></script>
<script src="frint.js"></script>

<!-- css-modules based framework, exposed as `window.CssFramework` -->
<script src="css-framework-using-css-modules.js"></script>

<!-- these Frint apps re-using vendors and CSS Framework from above -->
<script src="root-frint-app.js"></script>
<script src="child-frint-app-1.js"></script>
<script src="child-frint-app-2.js"></script>
```

Basically, I don't want Frint App bundles to include any CSS Framework code, since it has already been loaded before.

And my Webpack config for bundling Frint Apps would look like this for `css-loader`:

```js
{
  test: /\.css$/,
  exclude: /node_modules/,
  use: [
    'style-loader',
    {
      loader: 'css-loader',
      options: {
        modules: true,
        importLoaders: 1,
        localIdentName: '[name]__[local]___[hash:base64:5]',

        // this is the new feature
        externals: {
          'css-framework/variables.css': 'CssFramework.variables'
        },
      }
    },
  ]
}
```

In any of the App bundles, when I do this:

```js
import styles from './styles.css';
```

And my `styles.css` imports something from `css-framework` package:

```css
@value variables: "css-framework/variables.css";
@value primary-color, secondary-color from variables;

.button {
  color: primary-color;
}
```

Instead of including the `css-framework` code in the bundle, it would get the values dynamically in the browser from the global `window.CssFramework.variables`.

**Does this PR introduce a breaking change?**

Possibly for old node versions, but I am happy to update them.

## Other information

Fully working proof-of-concept with [FrintJS](https://frint.js.org) here: https://github.com/fahad19/frint-css-poc