### PR TITLE
perf: use modules only if explicitly set

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -14,7 +14,6 @@ module.exports = function(content, map) {
 	var callback = this.async();
 	var query = loaderUtils.getOptions(this) || {};
 	var root = query.root;
-	var moduleMode = query.modules || query.module;
 	var camelCaseKeys = query.camelCase || query.camelcase;
 	var resolve = createResolver(query.alias);
 
@@ -23,7 +22,6 @@ module.exports = function(content, map) {
 	}
 
 	processCss(content, map, {
-		mode: moduleMode ? "local" : "global",
 		from: loaderUtils.getRemainingRequest(this),
 		to: loaderUtils.getCurrentRequest(this),
 		query: query,

--- a/lib/localsLoader.js
+++ b/lib/localsLoader.js
@@ -12,11 +12,9 @@ module.exports = function(content) {
 	if(this.cacheable) this.cacheable();
 	var callback = this.async();
 	var query = loaderUtils.getOptions(this) || {};
-	var moduleMode = query.modules || query.module;
 	var camelCaseKeys = query.camelCase || query.camelcase;
 
 	processCss(content, null, {
-		mode: moduleMode ? "local" : "global",
 		query: query,
 		minimize: this.minimize,
 		loaderContext: this

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -47,7 +47,9 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 				} else throw rule.error("Unexpected format" + rule.params);
 				values.nodes[0].nodes.shift();
 				var mediaQuery = Tokenizer.stringifyValues(values);
-				if(loaderUtils.isUrlRequest(url, options.root) && options.mode === "global") {
+				if((!options.modules && loaderUtils.isUrlRequest(url, options.root))
+					|| (loaderUtils.isUrlRequest(url, options.root) && options.mode === "global")
+				) {
 					url = loaderUtils.urlToRequest(url, options.root);
 				}
 				importItems.push({
@@ -58,25 +60,27 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 			});
 		}
 
-		css.walkRules(function(rule) {
-			if(rule.selector === ":export") {
-				rule.walkDecls(function(decl) {
-					exports[decl.prop] = decl.value;
-				});
-				rule.remove();
-			} else if(/^:import\(.+\)$/.test(rule.selector)) {
-				var match = /^:import\((.+)\)$/.exec(rule.selector);
-				var url = loaderUtils.parseString(match[1]);
-				rule.walkDecls(function(decl) {
-					imports["$" + decl.prop] = importItems.length;
-					importItems.push({
-						url: url,
-						export: decl.value
+		if (options.modules) {
+			css.walkRules(function (rule) {
+				if (rule.selector === ":export") {
+					rule.walkDecls(function (decl) {
+						exports[decl.prop] = decl.value;
 					});
-				});
-				rule.remove();
-			}
-		});
+					rule.remove();
+				} else if (/^:import\(.+\)$/.test(rule.selector)) {
+					var match = /^:import\((.+)\)$/.exec(rule.selector);
+					var url = loaderUtils.parseString(match[1]);
+					rule.walkDecls(function (decl) {
+						imports["$" + decl.prop] = importItems.length;
+						importItems.push({
+							url: url,
+							export: decl.value
+						});
+					});
+					rule.remove();
+				}
+			});
+		}
 
 		Object.keys(exports).forEach(function(exportName) {
 			exports[exportName] = replaceImportsInString(exports[exportName]);
@@ -97,15 +101,21 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 					}
 					break;
 				case "url":
-					if (options.url && !/^#/.test(item.url) && loaderUtils.isUrlRequest(item.url, options.root)) {
-						item.stringType = "";
-						delete item.innerSpacingBefore;
-						delete item.innerSpacingAfter;
-						var url = item.url;
-						item.url = "___CSS_LOADER_URL___" + urlItems.length + "___";
-						urlItems.push({
-							url: url
-						});
+					if (options.url && !/^#/.test(item.url)) {
+						if (!options.modules && loaderUtils.isUrlRequest(item.url, options.root)) {
+							item.url = loaderUtils.urlToRequest(item.url, options.root);
+						}
+
+						if (loaderUtils.isUrlRequest(item.url, options.root)) {
+							item.stringType = "";
+							delete item.innerSpacingBefore;
+							delete item.innerSpacingAfter;
+							var url = item.url;
+							item.url = "___CSS_LOADER_URL___" + urlItems.length + "___";
+							urlItems.push({
+								url: url
+							});
+						}
 					}
 					break;
 			}
@@ -134,6 +144,9 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 	var query = options.query;
 	var root = query.root;
 	var context = query.context;
+	var modules = query.modules || query.module;
+    var moduleMode = query.moduleMode || query.moduleMode;
+    var defaultModuleMode = modules ? "local" : "global";
 	var localIdentName = query.localIdentName || "[hash:base64]";
 	var localIdentRegExp = query.localIdentRegExp;
 	var forceMinimize = query.minimize;
@@ -143,39 +156,47 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 
 	var parserOptions = {
 		root: root,
-		mode: options.mode,
+		mode: moduleMode,
+        modules: modules,
 		url: query.url !== false,
 		import: query.import !== false
 	};
 
-	var pipeline = postcss([
-		localByDefault({
-			mode: options.mode,
-			rewriteUrl: function(global, url) {
-				if(parserOptions.url){
-					if(!loaderUtils.isUrlRequest(url, root)) {
-						return url;
+	var plugins = [];
+
+	if (modules) {
+		plugins.push(
+			localByDefault({
+				mode: moduleMode ? moduleMode : defaultModuleMode,
+				rewriteUrl: function(global, url) {
+					if(parserOptions.url){
+						if(!loaderUtils.isUrlRequest(url, root)) {
+							return url;
+						}
+						if(global) {
+							return loaderUtils.urlToRequest(url, root);
+						}
 					}
-					if(global) {
-						return loaderUtils.urlToRequest(url, root);
-					}
+					return url;
 				}
-				return url;
-			}
-		}),
-		extractImports(),
-		modulesValues,
-		modulesScope({
-			generateScopedName: function generateScopedName (exportName) {
-				return customGetLocalIdent(options.loaderContext, localIdentName, exportName, {
-					regExp: localIdentRegExp,
-					hashPrefix: query.hashPrefix || "",
-					context: context
-				});
-			}
-		}),
-		parserPlugin(parserOptions)
-	]);
+			}),
+			extractImports(),
+			modulesValues,
+			modulesScope({
+				generateScopedName: function generateScopedName (exportName) {
+					return customGetLocalIdent(options.loaderContext, localIdentName, exportName, {
+						regExp: localIdentRegExp,
+						hashPrefix: query.hashPrefix || "",
+						context: context
+					});
+				}
+			})
+		);
+	}
+
+	plugins.push(parserPlugin(parserOptions));
+
+	var pipeline = postcss(plugins);
 
 	if(minimize) {
 		var cssnano = require("cssnano");

--- a/test/customGetLocalIdentTest.js
+++ b/test/customGetLocalIdentTest.js
@@ -11,6 +11,8 @@ describe("customGetLocalIdent", function() {
 			jkl: "foo"
 		},
         {
+            modules: true,
+            moduleMode: 'global',
             getLocalIdent: function () {
                 return 'foo'
             }

--- a/test/localTest.js
+++ b/test/localTest.js
@@ -18,7 +18,7 @@ describe("local", function() {
 		[1, ".test-2_pBx { background: red; }", ""]
 	], {
 		test: "test-2_pBx"
-	}, "?localIdentName=[local]-[hash:base64:5]");
+	}, "?modules&localIdentName=[local]-[hash:base64:5]");
 	testLocal("locals", ":local(.className) { background: red; }\n:local(#someId) { background: green; }\n" +
 		":local(.className .subClass) { color: green; }\n:local(#someId .subClass) { color: blue; }", [
 		[1, "._23J0282swY7bwvI2X4fHiV { background: red; }\n#_3vpqN0v_IxlO3TzQjbpB33 { background: green; }\n" +
@@ -27,14 +27,14 @@ describe("local", function() {
 		className: "_23J0282swY7bwvI2X4fHiV",
 		someId: "_3vpqN0v_IxlO3TzQjbpB33",
 		subClass: "_1s1VsToXFz17cPAltMg7jz"
-	});
+	}, "?modules");
 	testLocalMinimize("minimized plus local", ":local(.localClass) { background: red; }\n:local .otherClass { background: red; }\n:local(.empty) { }", [
 		[1, "._localClass,._otherClass{background:red}", ""]
 	], {
 		localClass: "_localClass",
 		otherClass: "_otherClass",
 		empty: "_empty"
-	}, "?localIdentName=_[local]");
+	}, "?modules&localIdentName=_[local]");
 	testLocal("mode switching", ".c1 :local .c2 .c3 :global .c4 :local .c5, .c6 :local .c7 { background: red; }\n.c8 { background: red; }", [
 		[1, ".c1 ._c2 ._c3 .c4 ._c5, .c6 ._c7 { background: red; }\n.c8 { background: red; }", ""]
 	], {
@@ -42,33 +42,33 @@ describe("local", function() {
 		c3: "_c3",
 		c5: "_c5",
 		c7: "_c7"
-	}, "?localIdentName=_[local]");
+	}, "?modules&moduleMode=global&localIdentName=_[local]");
 	testLocal("comment in local", ":local(.c1/*.c2*/.c3) { background: red; }", [
 		[1, "._c1._c3 { background: red; }", ""]
 	], {
 		c1: "_c1",
 		c3: "_c3"
-	}, "?localIdentName=_[local]");
+	}, "?modules&localIdentName=_[local]");
 	testLocal("comment in local", ":local(.c1/*.c2*/.c3) { background: red; }", [
 		[1, "._c1._c3 { background: red; }", ""]
 	], {
 		c1: "_c1",
 		c3: "_c3"
-	}, "?localIdentName=_[local]");
+	}, "?modules&localIdentName=_[local]");
 	testLocal("strings in local", ":local(.c1[data-attr=\".c2)]'\"]:not(.c3):not(.c4)) { background: red; }", [
 		[1, "._c1[data-attr=\".c2)]'\"]:not(._c3):not(._c4) { background: red; }", ""]
 	], {
 		c1: "_c1",
 		c3: "_c3",
 		c4: "_c4"
-	}, "?localIdentName=_[local]");
+	}, "?modules&localIdentName=_[local]");
 
 	testLocal("composes class simple", ":local(.c1) { a: 1; }\n:local(.c2) { composes: c1; b: 1; }", [
 		[1, "._c1 { a: 1; }\n._c2 { b: 1; }", ""]
 	], {
 		c1: "_c1",
 		c2: "_c2 _c1"
-	}, "?localIdentName=_[local]");
+	}, "?modules&localIdentName=_[local]");
 	testLocal("composes class from module", [
 		":local(.c1) { composes: c2 from \"./module\"; b: 1; }",
 		":local(.c3) { composes: c1; b: 3; }",
@@ -84,7 +84,7 @@ describe("local", function() {
 		c1: "_c1 imported-c2",
 		c3: "_c3 _c1 imported-c2",
 		c5: "_c5 imported-c2 imported-c4"
-	}, "?localIdentName=_[local]", {
+	}, "?modules&localIdentName=_[local]", {
 		"./module": (function() {
 			var r = [
 				[2, ".test{c: d}", ""]
@@ -111,7 +111,7 @@ describe("local", function() {
 		c1: "_c1 imported-c-2",
 		c3: "_c3 _c1 imported-c-2",
 		c5: "_c5 imported-c-2 imported-c4"
-	}, "?localIdentName=_[local]", {
+	}, "?modules&localIdentName=_[local]", {
 		"./module": (function() {
 			var r = [
 				[2, ".test{c: d}", ""]
@@ -131,7 +131,7 @@ describe("local", function() {
 		[1, "._c1 { b: 1; }", ""]
 	], {
 		c1: "_c1 imported-c2 imported-c3 imported-c4"
-	}, "?localIdentName=_[local]", {
+	}, "?modules&moduleMode=global&localIdentName=_[local]", {
 		"./module": (function() {
 			var r = [
 				[2, ".test{c: d}", ""]
@@ -152,18 +152,18 @@ describe("local", function() {
 		className: "_23J0282swY7bwvI2X4fHiV",
 		someId: "_3vpqN0v_IxlO3TzQjbpB33",
 		subClass: "_1s1VsToXFz17cPAltMg7jz"
-	}, "?module");
+	}, "?modules");
 	testLocal("class name parsing", ".-a0-34a___f { color: red; }", [
 		[1, "._3ZMCqVa1XidxdqbX65hZ5D { color: red; }", ""]
 	], {
 		"-a0-34a___f": "_3ZMCqVa1XidxdqbX65hZ5D"
-	}, "?module");
+	}, "?modules");
 	testLocal("imported values in decl", ".className { color: IMPORTED_NAME; }\n" +
 		":import(\"./vars.css\") { IMPORTED_NAME: primary-color; }", [
 		[1, "._className { color: red; }", ""]
 	], {
 		"className": "_className"
-	}, "?module&localIdentName=_[local]", {
+	}, "?modules&localIdentName=_[local]", {
 		"./vars.css": {
 			locals: {
 				"primary-color": "red"
@@ -206,15 +206,15 @@ describe("local", function() {
 		[1, "._1test { background: red; }", ""]
 	], {
 		test: "_1test"
-	}, "?localIdentName=1[local]");
+	}, "?modules&localIdentName=1[local]");
 	testLocal("prefixes leading hyphen + digit with underscore", ":local(.test) { background: red; }", [
 		[1, "._-1test { background: red; }", ""]
 	], {
 		test: "_-1test"
-	}, "?localIdentName=-1[local]");
+	}, "?modules&localIdentName=-1[local]");
 	testLocal("prefixes two leading hyphens with underscore", ":local(.test) { background: red; }", [
 		[1, "._--test { background: red; }", ""]
 	], {
 		test: "_--test"
-	}, "?localIdentName=--[local]");
+	}, "?modules&localIdentName=--[local]");
 });

--- a/test/localsTest.js
+++ b/test/localsTest.js
@@ -10,7 +10,7 @@ describe("locals", function() {
 			ghi: "_ghi",
 			jkl: "_jkl"
 		},
-		"?localIdentName=_[local]"
+		"?modules&moduleMode=global&localIdentName=_[local]"
 	);
 	testLocals("should return only locals with composing",
 		":local(.abc) { color: red; } :local(.def) { composes: abc; background: green; }",
@@ -18,14 +18,14 @@ describe("locals", function() {
 			abc: "_abc",
 			def: "_def _abc"
 		},
-		"?localIdentName=_[local]"
+		"?modules&localIdentName=_[local]"
 	);
 	testLocals("should return only locals with importing",
 		":local(.abc) { composes: def from \"./module.css\"; }",
 		{
 			abc: "_abc imported_def imported_ghi"
 		},
-		"?localIdentName=_[local]",
+		"?modules&localIdentName=_[local]",
 		{
 			"./module.css": {
 				def: "imported_def imported_ghi",
@@ -38,7 +38,7 @@ describe("locals", function() {
 		{
 			abc: "_abc imported_def1 imported_ghi1 imported_def2"
 		},
-		"?localIdentName=_[local]",
+		"?modules&localIdentName=_[local]",
 		{
 			"./module1.css": {
 				def: "imported_def1 imported_ghi1",

--- a/test/valuesTest.js
+++ b/test/valuesTest.js
@@ -15,7 +15,7 @@ describe("values", function() {
 			def: "red",
 			ghi: "1px solid black"
 		},
-		""
+		"?modules"
 	);
 	testLocals("should export values and locals",
 		"@value def: red; .ghi { color: def; }",
@@ -31,7 +31,7 @@ describe("values", function() {
 			[ 1, ".ghi { color: red; }", "" ]
 		], {
 			def: "red"
-		}, "", {
+		}, "?modules&moduleMode=global", {
 			"./file": (function() {
 				var a =  [[2, "", ""]];
 				a.locals = {
@@ -49,7 +49,7 @@ describe("values", function() {
 		], {
 			aaa: "red",
 			bbb: "green"
-		}, "", {
+		}, "?modules&moduleMode=global", {
 			"./file1": (function() {
 				var a =  [[2, "", ""]];
 				a.locals = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix 

**Did you add tests for your changes?**

Already have.

**If relevant, did you update the README?**

After accept.

**Summary**

Now `css-loader` it is not loader for `css`, many project don't use `css-modules` for their project, but seems (https://github.com/webpack-contrib/css-loader/blob/master/lib/processCss.js#L152) they are use **always**. We spend a lot of time on `postcss-modules-*`, even if I set `modules: false`. I think this is completely wrong and many issue about performance probably related to this. Right name for this loader is `css-modules-loader`.

`postcss-loader` in v2 (i hope we can release it faster) wants to abandon `css-loader`, allow use only `postcss-loader` handle `css` and etc stuff (url, imports and etc). In fact, this is the real `css-loader`, It is simple, does not contain any logic.

What we can do?
1. Merge this PR before release `css-loader` (`css-modules-loader`) v1 and `postcss-loader` v2 (fix performance for project don't use `css-modules`).
2. Move all logic not related to `css-modules` (urls, improts and etc stuff) to `postcss-loader`.
3. Deprecated `css-loader` in favor `css-modules-loader`.
4. ...
5. PROFIT (better performance to project don't using `css-modules`, clear logic for `postcss-loader` and `css-modules-loader`, separation of issues - related to `css-modules` in `css-modules-loader`, related to `css` in `postcss-loader`)

Ref about `postcss-loader` `v2`: https://github.com/postcss/postcss-loader/issues/177

**Does this PR introduce a breaking change?**

Should not.

**Other information**

Not required.
