### PR TITLE
docs(README): update import section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ To disable `@import` resolving by `css-loader` set the option to `false`
 @import url('https://fonts.googleapis.com/css?family=Roboto');
 ```
 
-> :waning: Use with caution, since this disables resolving for **all** `@import`s
+> :waning: Use with caution, since this disables resolving for **all** `@import`s, including css modules `composes: xxx from 'path/to/file.css'` feature.
 
 ### [`modules`](https://github.com/css-modules/css-modules)
 


### PR DESCRIPTION
Gosh, I spent so much time understanding why I was able to compose a class with an internal class but not an external class in my css moduled style files.

I wanted to disable "import" because I didn't want that people use "@import" in the css files and wanted them make it importing via javascript like this:

```javascript
import '~/styles/index.css'
import styles from './index.css'
```

*BUT* disabling "import" option makes unavailable the fact to import external class in css-modules `composes` feature.

😒😒😒😒
