### PR TITLE
docs(README): add extract-loader example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ plain string resource (i.e. not wrapped in a JS module) you
 might want to check out the [extract-loader](https://github.com/peerigon/extract-loader).
 It's useful when you, for instance, need to post process the CSS as a string.
 
+**webpack.config.js**
+```js
+{
+   test: /\.css$/,
+   use: [
+     'handlebars-loader', // handlebars loader expects raw resource string
+     'extract-loader',
+     'css-loader'
+   ]
+}
+```
+
 <h2 align="center">Options</h2>
 
 |Name|Type|Default|Description|

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ console.log(css); // {String}
 
 If there are SourceMaps, they will also be included in the result string.
 
+If, for one reason or another, you need to extract CSS as a
+plain string resource (i.e. not wrapped in a JS module) you
+might want to check out the [extract-loader](https://github.com/peerigon/extract-loader). It's useful when you, for instance, need to post-process the CSS as a string.
+
 <h2 align="center">Options</h2>
 
 |Name|Type|Default|Description|

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ If there are SourceMaps, they will also be included in the result string.
 
 If, for one reason or another, you need to extract CSS as a
 plain string resource (i.e. not wrapped in a JS module) you
-might want to check out the [extract-loader](https://github.com/peerigon/extract-loader). It's useful when you, for instance, need to post-process the CSS as a string.
+might want to check out the [extract-loader](https://github.com/peerigon/extract-loader).
+It's useful when you, for instance, need to post process the CSS as a string.
 
 <h2 align="center">Options</h2>
 


### PR DESCRIPTION
Recently needed this and I think it’s worth documenting for other folks. Took me a few days to figure out.

The difference between to-string-loader and extract-loader is that former wraps the CSS in a JS module while latter executes the css-loader’s output at compile time and passes that to the next loader in the chain. Came in handy when we needed some further post processing.