### PR TITLE
feat: add `options.matchImportLoadersByOrigin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ It's useful when you, for instance, need to post process the CSS as a string.
 |**`sourceMap`**|`{Boolean}`|`false`|Enable/Disable Sourcemaps|
 |**`camelCase`**|`{Boolean\|String}`|`false`|Export Classnames in CamelCase|
 |**`importLoaders`**|`{Number}`|`0`|Number of loaders applied before CSS loader|
+|**`matchImportLoadersByOrigin`**|`{Boolean}`|`false`|Match import loaders by origin through webpack.config|
 
 ### `root`
 
@@ -428,6 +429,48 @@ The query parameter `importLoaders` allows to configure how many loaders before 
 ```
 
 This may change in the future, when the module system (i. e. webpack) supports loader matching by origin.
+
+### `matchImportLoadersByOrigin`
+
+The query parameter `matchImportLoadersByOrigin` allows to match and use import loaders, defined in webpack.config, for `@import`ed and composed resources.
+
+**webpack.config.js**
+```js
+{
+  test: /\.css$/,
+  use: [
+    'style-loader',
+    {
+      loader: 'css-loader',
+      options: {
+        matchImportLoadersByOrigin: true // false => use same loaders as for current file (default); true => match import loaders through webpack.config
+      }
+    },
+    'postcss-loader'
+  ]
+}, {
+  test: /\.sass$/,
+  use: [
+    'style-loader',
+    {
+      loader: 'css-loader',
+      options: {
+        matchImportLoadersByOrigin: true // false => use same loaders as for current file (default); true => match import loaders through webpack.config
+      }
+    },
+    'postcss-loader',
+    'sass-loader'
+  ]
+}
+```
+
+Composing with matchImportLoadersByOrigin set to true. Since imports are resolved through webpack, it is also possible to import from different file types.
+
+```css
+  .class-name {
+    composes: another-class-name from "./some-other-classes.sass"
+  }
+```
 
 <h2 align="center">Examples</h2>
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -53,6 +53,10 @@ module.exports = function(content, map) {
 		// for importing CSS
 		var importUrlPrefix = getImportPrefix(this, query);
 
+		if (query.matchImportLoadersByOrigin) {
+			importUrlPrefix = "";
+		}
+
 		var alreadyImported = {};
 		var importJs = result.importItems.filter(function(imp) {
 			if(!imp.mediaQuery) {
@@ -77,6 +81,12 @@ module.exports = function(content, map) {
 			var idx = +match[1];
 			var importItem = result.importItems[idx];
 			var importUrl = importUrlPrefix + importItem.url;
+
+			if (query.matchImportLoadersByOrigin) {
+				return "\" + require(" + loaderUtils.stringifyRequest(this, importUrl) + ")" +
+					"[" + JSON.stringify(importItem.export) + "] + \"";
+			}
+
 			return "\" + require(" + loaderUtils.stringifyRequest(this, importUrl) + ").locals" +
 				"[" + JSON.stringify(importItem.export) + "] + \"";
 		}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR introduces a new config option called "matchImportLoadersByOrigin" config option. With this config option set to true, all imports (@import and composes) are resolved matching webpack loaders by it's origin instead of just using the same loader chain, that was used for it's containing file. importLoaders config option is not needed anymore, when using matchImportLoadersByOrigin.

https://github.com/webpack-contrib/css-loader/pull/287 is closely related and probably even the more solid version, but without config option. I do not understand why this never has been merged since it would solve so many issues.

**Did you add tests for your changes?**
If it is needed, i can add tests. First of all i would like to see, if my changes make sense.

**If relevant, did you update the README?**
Yes.

**Summary**
This should resolve the following issues:
https://github.com/webpack-contrib/css-loader/issues/286
https://github.com/webpack-contrib/css-loader/issues/131
https://github.com/css-modules/css-modules/issues/110
https://github.com/css-modules/css-modules/issues/170

**Does this PR introduce a breaking change?**
No
