### PR TITLE
docs(README): fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ To import from multiple modules use multiple `composes:` rules.
 
 By default the css-loader minimizes the css if specified by the module system.
 
-In some cases the minification is destructive to the css, so you can provide your own options to the cssnano-based minifier if needed. See [cssnano's documenation](http://cssnano.co/guides/) for more information on the available options.
+In some cases the minification is destructive to the css, so you can provide your own options to the cssnano-based minifier if needed. See [cssnano's documentation](http://cssnano.co/guides/) for more information on the available options.
 
 You can also disable or enforce minification with the `minimize` query parameter.
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ To import from multiple modules use multiple `composes:` rules.
 
 By default the css-loader minimizes the css if specified by the module system.
 
-In some cases the minification is destructive to the css, so you can provide your own options to the minifier if needed. cssnano is used for minification and you find a [list of options here](http://cssnano.co/options/).
+In some cases the minification is destructive to the css, so you can provide your own options to the cssnano-based minifier if needed. See [cssnano's documenation](http://cssnano.co/guides/) for more information on the available options.
 
 You can also disable or enforce minification with the `minimize` query parameter.
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
readme fix

**Did you add tests for your changes?**
no

**If relevant, did you update the README?**
yes

**Summary**
cssnano.co/options/ is currently a 404 as it looks like they changed their routing
structure. This was throwing broken link errors on webpack.js.org as we dynamically
pull this readme.

**Does this PR introduce a breaking change?**
no
