### PR TITLE
fix: match mutliple dashes (`options.camelCase`)

### DIFF
--- a/lib/compile-exports.js
+++ b/lib/compile-exports.js
@@ -1,7 +1,7 @@
 var camelCase = require("lodash.camelcase");
 
 function dashesCamelCase(str) {
-  return str.replace(/-(\w)/g, function(match, firstLetter) {
+  return str.replace(/-{1,}(\w)/g, function(match, firstLetter) {
     return firstLetter.toUpperCase();
   });
 }

--- a/lib/compile-exports.js
+++ b/lib/compile-exports.js
@@ -1,7 +1,7 @@
 var camelCase = require("lodash.camelcase");
 
 function dashesCamelCase(str) {
-  return str.replace(/-{1,}(\w)/g, function(match, firstLetter) {
+  return str.replace(/-+(\w)/g, function(match, firstLetter) {
     return firstLetter.toUpperCase();
   });
 }

--- a/test/camelCaseTest.js
+++ b/test/camelCaseTest.js
@@ -5,6 +5,7 @@ var testRaw = require("./helpers").testRaw;
 
 describe("camelCase", function() {
 	var css = ".btn-info_is-disabled { color: blue; }";
+	var cssMultipleDashes = ".btn--info_is-disabled { color: blue; }";
 	var mixedCss = ".btn-info_is-disabled { color: blue; } .simple { color: red; }";
 	var exports = {
 		with: [
@@ -16,6 +17,9 @@ describe("camelCase", function() {
 		dashes: [
 			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; }", ""]
 		],
+		multipleDashes: [
+			[1, "._3JUlsKrl__OF70Fq391jEw { color: blue; }", ""]
+		],
 		withoutOnly: [
 			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; } .KKtodWG-IuEaequFjAsoJ { color: red; }", ""]
 		],
@@ -26,11 +30,13 @@ describe("camelCase", function() {
 	exports.with.locals = {'btn-info_is-disabled': '_1L-rnCOXCE_7H94L5XT4uB'};
 	exports.without.locals = {btnInfoIsDisabled: '_1L-rnCOXCE_7H94L5XT4uB', 'btn-info_is-disabled': '_1L-rnCOXCE_7H94L5XT4uB'};
 	exports.dashes.locals = {btnInfo_isDisabled: '_1L-rnCOXCE_7H94L5XT4uB', 'btn-info_is-disabled': '_1L-rnCOXCE_7H94L5XT4uB'};
+	exports.multipleDashes.locals = {btnInfo_isDisabled: '_3JUlsKrl__OF70Fq391jEw', 'btn--info_is-disabled': '_3JUlsKrl__OF70Fq391jEw'};
 	exports.withoutOnly.locals = {btnInfoIsDisabled: '_1L-rnCOXCE_7H94L5XT4uB', simple: 'KKtodWG-IuEaequFjAsoJ'};
 	exports.dashesOnly.locals = {btnInfo_isDisabled: '_1L-rnCOXCE_7H94L5XT4uB', simple: 'KKtodWG-IuEaequFjAsoJ'};
 	test("with", css, exports.with, "?modules");
 	test("without", css, exports.without, "?modules&camelCase");
 	test("dashes", css, exports.dashes, "?modules&camelCase=dashes");
+	test("multipleDashes", cssMultipleDashes, exports.multipleDashes, "?modules&camelCase=dashes");
 	// Remove this option in v1.0.0 and make the removal of the original classname the default behaviour. See #440.
 	test("withoutOnly", mixedCss, exports.withoutOnly, "?modules&camelCase=only");
 	// Remove this option in v1.0.0 and make the removal of the original classname the default behaviour. See #440.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Regex tweak for matching dashes in class names.

**Did you add tests for your changes?**
No

**Summary**
I was running into the same issue as https://github.com/webpack-contrib/css-loader/issues/244 whereby classes with double dashes in it still had one dash left even though I have camelCase set to 'dashes'. All I've done is change the regex to match one or more dashes and remove them all. 

**Does this PR introduce a breaking change?**
Not to my knowledge, all tests pass.
