### PR TITLE
docs(README): `importLoaders` should be 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ The query parameter `importLoaders` allows to configure how many loaders before 
     {
       loader: 'css-loader',
       options: {
-        importLoaders: 1 // 0 => no loaders (default); 1 => postcss-loader; 2 => postcss-loader, sass-loader
+        importLoaders: 2 // 0 => no loaders (default); 1 => postcss-loader; 2 => postcss-loader, sass-loader
       }
     },
     'postcss-loader',


### PR DESCRIPTION
importLoader should be 2 because there is postcss-loader and sass-loader after it.

PS:
I don't understand this option, it works without it, why is it for ?
