### PR TITLE
feat: show warning when `NODE_ENV === 'production'` and `!query.minimize`

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -7,7 +7,7 @@ var processCss = require("./processCss");
 var getImportPrefix = require("./getImportPrefix");
 var compileExports = require("./compile-exports");
 var createResolver = require("./createResolver");
-
+var warnings = require("./warnings");
 
 module.exports = function(content, map) {
 	if(this.cacheable) this.cacheable();
@@ -18,6 +18,9 @@ module.exports = function(content, map) {
 	var camelCaseKeys = query.camelCase || query.camelcase;
 	var sourceMap = query.sourceMap || false;
 	var resolve = createResolver(query.alias);
+
+  // suggest minimizing to user on production build
+  warnings.minimizeInProduction(query.minimize, process);
 
 	if(sourceMap) {
 		if (map) {

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -8,18 +8,15 @@ var cachedProcessId = 0;
  * @param {Object} processObject current process object
  * @returns {undefined}
  */
-function minimizeInProduction(minimize, processObject) {
+function minimizeInProduction(minimize, processObject, loader) {
   if (processObject.env.NODE_ENV === "production" && !minimize && processObject.pid !== cachedProcessId) {
     // update process id
     cachedProcessId = processObject.pid;
 
     // show warning
-    minimizeInProduction.console.warn("[css-loader] Building for production? We suggest enabling minimize (https://github.com/webpack-contrib/css-loader#minimize).\n");
+    loader.emitWarning("\n\nCSS Loader\n\n" + "Building for production?\n" + "We suggest enabling minimize (https://github.com/webpack-contrib/css-loader#minimize).\n");
   }
 }
-
-// allow console object mock up during test
-minimizeInProduction.console = console;
 
 module.exports = {
   minimizeInProduction: minimizeInProduction

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -6,6 +6,7 @@ var cachedProcessId = 0;
  * @method minimizeInProduction
  * @param {Boolean} minimize minimize value form query
  * @param {Object} processObject current process object
+ * @param {Object} loader current loader context
  * @returns {undefined}
  */
 function minimizeInProduction(minimize, processObject, loader) {
@@ -14,7 +15,7 @@ function minimizeInProduction(minimize, processObject, loader) {
     cachedProcessId = processObject.pid;
 
     // show warning
-    loader.emitWarning("\n\nCSS Loader\n\n" + "Building for production?\n" + "We suggest enabling minimize (https://github.com/webpack-contrib/css-loader#minimize).\n");
+    loader.emitWarning("\n\nCSS Loader\n\nBuilding for production?\nWe suggest enabling minimize (https://github.com/webpack-contrib/css-loader#minimize).\n");
   }
 }
 

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -4,8 +4,9 @@ var cachedProcessId = 0;
 /**
  * Shows one warning per process if NODE_ENV is production and minimize is not enabled
  * @method minimizeInProduction
- * @param {Boolean} minimize
- * @param {Object} processObject
+ * @param {Boolean} minimize minimize value form query
+ * @param {Object} processObject current process object
+ * @returns {undefined}
  */
 function minimizeInProduction(minimize, processObject) {
   if (processObject.env.NODE_ENV === "production" && !minimize && processObject.pid !== cachedProcessId) {
@@ -13,12 +14,12 @@ function minimizeInProduction(minimize, processObject) {
     cachedProcessId = processObject.pid;
 
     // show warning
-    minimizeInProduction._console.warn("[css-loader] Building for production? We suggest enabling minimize (https://github.com/webpack-contrib/css-loader#minimize).\n");
+    minimizeInProduction.console.warn("[css-loader] Building for production? We suggest enabling minimize (https://github.com/webpack-contrib/css-loader#minimize).\n");
   }
 }
 
 // allow console object mock up during test
-minimizeInProduction._console = console;
+minimizeInProduction.console = console;
 
 module.exports = {
   minimizeInProduction: minimizeInProduction

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -1,0 +1,25 @@
+// cache process id
+var cachedProcessId = 0;
+
+/**
+ * Shows one warning per process if NODE_ENV is production and minimize is not enabled
+ * @method minimizeInProduction
+ * @param {Boolean} minimize
+ * @param {Object} processObject
+ */
+function minimizeInProduction(minimize, processObject) {
+  if (processObject.env.NODE_ENV === "production" && !minimize && processObject.pid !== cachedProcessId) {
+    // update process id
+    cachedProcessId = processObject.pid;
+
+    // show warning
+    minimizeInProduction._console.warn("[css-loader] Building for production? We suggest enabling minimize (https://github.com/webpack-contrib/css-loader#minimize).\n");
+  }
+}
+
+// allow console object mock up during test
+minimizeInProduction._console = console;
+
+module.exports = {
+  minimizeInProduction: minimizeInProduction
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "should": "^11.1.2",
+    "should-spies": "^1.1.0",
     "standard-version": "^4.0.0"
   },
   "scripts": {

--- a/test/warningsTest.js
+++ b/test/warningsTest.js
@@ -7,7 +7,6 @@ var warnings = require("../lib/warnings");
 
 
 describe("warnings", function() {
-  var originalConsole = console;
   var warningSpy;
   var mockedLoader;
 

--- a/test/warningsTest.js
+++ b/test/warningsTest.js
@@ -1,0 +1,67 @@
+/*eslint-env mocha*/
+
+var should = require("should");
+require("should-spies");
+
+var warnings = require("../lib/warnings");
+
+
+describe("warnings", function() {
+  var originalConsole = console;
+  var warningSpy;
+  var mockedConsole;
+
+  beforeEach(function() {
+    mockedConsole = {
+      warn: function() {}
+    }
+
+    warnings.minimizeInProduction._console = mockedConsole;
+
+    warningSpy = should.spy.on(mockedConsole, 'warn');
+  });
+
+  afterEach(function() {
+    warnings.minimizeInProduction._console = originalConsole;
+  });
+
+  it("minimize warning is displayed on production when minimized is false", function() {
+    var mockedProcess = {
+      pid: 1,
+      env: {
+        NODE_ENV: "production"
+      }
+    };
+
+    warnings.minimizeInProduction(false, mockedProcess);
+
+    warningSpy.should.be.called();
+  });
+
+  it("minimize warning is not displayed on production when minimized is true", function() {
+    var mockedProcess = {
+      pid: 1,
+      env: {
+        NODE_ENV: "production"
+      }
+    };
+
+    warnings.minimizeInProduction(true, mockedProcess);
+
+    warningSpy.should.not.be.called();
+  });
+
+  it("minimize warning is not displayed on production when minimized is an object", function() {
+    var mockedProcess = {
+      pid: 1,
+      env: {
+        NODE_ENV: "production"
+      }
+    };
+
+    warnings.minimizeInProduction({}, mockedProcess);
+
+    warningSpy.should.not.be.called();
+  });
+
+});

--- a/test/warningsTest.js
+++ b/test/warningsTest.js
@@ -9,22 +9,20 @@ var warnings = require("../lib/warnings");
 describe("warnings", function() {
   var originalConsole = console;
   var warningSpy;
-  var mockedConsole;
+  var mockedLoader;
 
   beforeEach(function() {
-    mockedConsole = {
-      warn: function() {
+    mockedLoader = {
+      emitWarning: function() {
         return undefined;
       }
     }
 
-    warnings.minimizeInProduction.console = mockedConsole;
-
-    warningSpy = should.spy.on(mockedConsole, 'warn');
+    warningSpy = should.spy.on(mockedLoader, 'emitWarning');
   });
 
   afterEach(function() {
-    warnings.minimizeInProduction.console = originalConsole;
+    warningSpy = null;
   });
 
   it("minimize warning is displayed on production when minimized is false", function() {
@@ -35,7 +33,7 @@ describe("warnings", function() {
       }
     };
 
-    warnings.minimizeInProduction(false, mockedProcess);
+    warnings.minimizeInProduction(false, mockedProcess, mockedLoader);
 
     warningSpy.should.be.called();
   });
@@ -48,7 +46,7 @@ describe("warnings", function() {
       }
     };
 
-    warnings.minimizeInProduction(true, mockedProcess);
+    warnings.minimizeInProduction(true, mockedProcess, mockedLoader);
 
     warningSpy.should.not.be.called();
   });
@@ -61,7 +59,7 @@ describe("warnings", function() {
       }
     };
 
-    warnings.minimizeInProduction({}, mockedProcess);
+    warnings.minimizeInProduction({}, mockedProcess, mockedLoader);
 
     warningSpy.should.not.be.called();
   });

--- a/test/warningsTest.js
+++ b/test/warningsTest.js
@@ -13,16 +13,18 @@ describe("warnings", function() {
 
   beforeEach(function() {
     mockedConsole = {
-      warn: function() {}
+      warn: function() {
+        return undefined;
+      }
     }
 
-    warnings.minimizeInProduction._console = mockedConsole;
+    warnings.minimizeInProduction.console = mockedConsole;
 
     warningSpy = should.spy.on(mockedConsole, 'warn');
   });
 
   afterEach(function() {
-    warnings.minimizeInProduction._console = originalConsole;
+    warnings.minimizeInProduction.console = originalConsole;
   });
 
   it("minimize warning is displayed on production when minimized is false", function() {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds a warning on terminal when `NODE_ENV` is `"production"` and `minimize` is _falsy_.

**Did you add tests for your changes?**
Yes.

**If relevant, did you update the README?**
No relevant.

**Summary**
While debugging my codebase and seeing the css injected by the `style-loader` after passing through `css-loader`, styles _looked_ minified but they are not, only spaces and line breaks are eliminated. This _wrong impression_ of css being minified when is just being collapsed might be happening to more people, missing the chance to reduce the bundle they are delivering in production.

Recently, Addy Osmani in his recent talk on FluentConf add this as something devs forget to do on production (https://twitter.com/housecor/status/877567271408869376).

**Does this PR introduce a breaking change?**
No.

**Other information**
I created a separate module to handle warnings, in case somebody wants to extend them in the future. Warning doesn't mutate any object, that's why it receives the process object and the minimize value. This also makes testing super easy.
