### PR TITLE
Inherit getLocalIdent from parent loader

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -18,6 +18,19 @@ module.exports = function(content, map) {
 	var camelCaseKeys = query.camelCase || query.camelcase;
 	var sourceMap = query.sourceMap || false;
 	var resolve = createResolver(query.alias);
+	// Inherit getLocalIdent from parent loader
+	/* eslint-disable no-underscore-dangle */
+	if(this._module && this._module.issuer && this._module.issuer.loaders) {
+		var filename = require.resolve("..");
+		var parentLoader = this._module.issuer.loaders.filter(function(loader) {
+			return loader.loader === filename;
+		})[0];
+		if(parentLoader && parentLoader.options) {
+			query.getLocalIdent = parentLoader.options.getLocalIdent;
+		}
+	}
+
+	/* eslint-enable no-underscore-dangle */
 
 	if(sourceMap) {
 		if (map) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bug fix.

**Did you add tests for your changes?**
No. (I couldn't figure out how to compose from a css file with the test helpers)

**Summary**
Someone using one of my libraries ran into an issue where getLocalIdent was not being applied to composed classes. (odensc/css-loader-minify-class#1)

Looking into the source code for css-loader, I found that the loader query is stringified sometimes - which causes it to lose the function reference to `getLocalIdent`. This PR fixes that by inheriting the getLocalIdent function from the parent loader if possible. 

Also fixes #524 which was reported on this repo.

**Does this PR introduce a breaking change?**
No.
