### PR TITLE
fix: stricter `@import` tolerance

### DIFF
--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -42,7 +42,7 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 		}
 
 		if(options.import) {
-			css.walkAtRules(/import/i, function(rule) {
+			css.walkAtRules(/^import$/i, function(rule) {
 				var values = Tokenizer.parseValues(rule.params);
 				var url = values.nodes[0].nodes[0];
 				if(url.type === "url") {

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -45,9 +45,9 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 			css.walkAtRules(/^import$/i, function(rule) {
 				var values = Tokenizer.parseValues(rule.params);
 				var url = values.nodes[0].nodes[0];
-				if(url.type === "url") {
+				if(url && url.type === "url") {
 					url = url.url;
-				} else if(url.type === "string") {
+				} else if(url && url.type === "string") {
 					url = url.value;
 				} else throw rule.error("Unexpected format " + rule.params);
 				if (!url.replace(/\s/g, '').length) {

--- a/test/importTest.js
+++ b/test/importTest.js
@@ -1,6 +1,10 @@
 /*globals describe */
 
-var test = require("./helpers").test;
+var assert = require('assert');
+
+var helpers = require("./helpers");
+var test = helpers.test;
+var testError = helpers.testError;
 
 describe("import", function() {
 	test("import", "@import url(test.css);\n.class { a: b c d; }", [
@@ -69,4 +73,13 @@ describe("import", function() {
 	test("@import-normalize left untouched", "@import-normalize;", [
 		[1, "@import-normalize;", ""]
 	]);
-});
+	testError("@import without url", "@import;", function(err) {
+		assert.equal(err.message, [
+			'Unexpected format  (1:1)',
+			'',
+			'> 1 | @import;',
+			'    | ^',
+			'',
+		].join('\n'))
+	})
+})

--- a/test/importTest.js
+++ b/test/importTest.js
@@ -66,4 +66,7 @@ describe("import", function() {
 	test("import disabled", "@import url(test.css);\n.class { a: b c d; }", [
 		[1, "@import url(test.css);\n.class { a: b c d; }", ""]
 	], "?-import");
+	test("@import-normalize left untouched", "@import-normalize;", [
+		[1, "@import-normalize;", ""]
+	]);
 });


### PR DESCRIPTION
I accidentally found this issue when using size-limit on an exported library where we kept the import-normalize from https://www.npmjs.com/package/postcss-normalize inside the exported library.

Issue is that Webpack currently throws on the simple statement as it tries to parse it as a normal import.

To fix I added the failing test first, then fixed the regexp which matches the import statements and made the url handling generally more tolerant.