### PR TITLE
docs(README): fix malformed link (`options.alias`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ url(~module/image.png) => require('module/image.png')
 
 Rewrite your urls with alias, this is useful when it's hard to change url paths of your input files, for example, when you're using some css / sass files in another package (bootstrap, ratchet, font-awesome, etc.).
 
-`css-loader`'s `alias` follows the same syntax as webpack's `resolve.alias`, you can see the details at the [resolve docs] (https://webpack.js.org/configuration/resolve/#resolve-alias)
+`css-loader`'s `alias` follows the same syntax as webpack's `resolve.alias`, you can see the details at the [resolve docs](https://webpack.js.org/configuration/resolve/#resolve-alias)
 
 **file.scss**
 ```css


### PR DESCRIPTION
Fixes:

**What kind of change does this PR introduce?**
README fix

**Did you add tests for your changes?**
No code changes, just markdown fix. Here's the test:

------------------------------------------

**Before:**
`css-loader`'s `alias` follows the same syntax as webpack's `resolve.alias`, you can see the details at the [resolve docs] (https://webpack.js.org/configuration/resolve/#resolve-alias)

**After:**
`css-loader`'s `alias` follows the same syntax as webpack's `resolve.alias`, you can see the details at the [resolve docs](https://webpack.js.org/configuration/resolve/#resolve-alias)

------------------------------------------

**If relevant, did you update the README?**
Yes, made a super minor fix to it

**Motivation**
Saw an incorrectly formatted link, wanted to fix it

**Does this PR introduce a breaking change?**
No breaking changes

