### PR TITLE
fix: add support for aliases starting with `/` (`options.alias`)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -42,6 +42,7 @@ module.exports = function(content, map) {
 		from: loaderUtils.getRemainingRequest(this).split("!").pop(),
 		to: loaderUtils.getCurrentRequest(this).split("!").pop(),
 		query: query,
+		resolve: resolve,
 		minimize: this.minimize,
 		loaderContext: this,
 		sourceMap: sourceMap

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -83,7 +83,7 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 			exports[exportName] = replaceImportsInString(exports[exportName]);
 		});
 
-		function startByAlias(url) {
+		function isAlias(url) {
 			// Handle alias starting by / and root disabled
 			return url !== options.resolve(url)
 		}
@@ -103,7 +103,7 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 					}
 					break;
 				case "url":
-					if (options.url && item.url.replace(/\s/g, '').length && !/^#/.test(item.url) && (startByAlias(item.url) || loaderUtils.isUrlRequest(item.url, options.root))) {
+					if (options.url && item.url.replace(/\s/g, '').length && !/^#/.test(item.url) && (isAlias(item.url) || loaderUtils.isUrlRequest(item.url, options.root))) {
 						// Don't remove quotes around url when contain space
 						if (item.url.indexOf(" ") === -1) {
 							item.stringType = "";

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -83,6 +83,11 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 			exports[exportName] = replaceImportsInString(exports[exportName]);
 		});
 
+		function startByAlias(url) {
+			// Handle alias starting by / and root disabled
+			return url !== options.resolve(url)
+		}
+
 		function processNode(item) {
 			switch (item.type) {
 				case "value":
@@ -98,7 +103,7 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 					}
 					break;
 				case "url":
-					if (options.url && item.url.replace(/\s/g, '').length && !/^#/.test(item.url) && loaderUtils.isUrlRequest(item.url, options.root)) {
+					if (options.url && item.url.replace(/\s/g, '').length && !/^#/.test(item.url) && (startByAlias(item.url) || loaderUtils.isUrlRequest(item.url, options.root))) {
 						// Don't remove quotes around url when contain space
 						if (item.url.indexOf(" ") === -1) {
 							item.stringType = "";
@@ -149,7 +154,8 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 		root: root,
 		mode: options.mode,
 		url: query.url !== false,
-		import: query.import !== false
+		import: query.import !== false,
+		resolve: options.resolve
 	};
 
 	var pipeline = postcss([

--- a/test/aliasTest.js
+++ b/test/aliasTest.js
@@ -28,3 +28,30 @@ describe("alias", function() {
 	test("exactMatch", css, exports.exactMatch, aliasOptions({ "./path/to/file.png$": "module/file.png" }));
 	test("notExactMatch", css, exports.notExactMatch, aliasOptions({ "./path/to/file.jpg$": "module/file.jpg" }));
 });
+
+describe("alias starting with /", function() {
+	var css = ".className { background: url(/path/to/file.png); }";
+	var exports = {
+		without: [
+			[1, ".className { background: url(/path/to/file.png); }", ""]
+		],
+		onlyModule: [
+			[1, ".className { background: url({module/file.png}); }", ""]
+		],
+		exactMatch: [
+			[1, ".className { background: url({module/file.png}); }", ""]
+		],
+		notExactMatch: [
+			[1, ".className { background: url(/path/to/file.png); }", ""]
+		]
+	};
+
+	function aliasOptions(alias) {
+		return { query: { alias: alias }}
+	}
+
+	test("without", css, exports.without);
+	test("onlyModule", css, exports.onlyModule, aliasOptions({ "/path/to": "module" }));
+	test("exactMatch", css, exports.exactMatch, aliasOptions({ "/path/to/file.png$": "module/file.png" }));
+	test("notExactMatch", css, exports.notExactMatch, aliasOptions({ "/path/to/file.jpg$": "module/file.jpg" }));
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Improvement in alias handling

**Did you add tests for your changes?**

Of course

**Summary**

Hi :)

Thank you for this great webpack loader. Actually, we are using it a lot into [nuxt.js](https://github.com/nuxt/nuxt.js).

We have an issue with the css-loader used into the vue files, we have a global webpack alias named `~` and it's used a lot to require file this way: `import '~/assets/my-file.vue'`

Actually, we are using `css-loader` with this configuration:
```js
{
    loader: 'css-loader',
    options: {
      minimize: true,
      importLoaders: 1,
      sourceMap: true,
      alias: {
        '/static': join(this.options.srcDir, 'static'),
        '/assets': join(this.options.srcDir, 'assets')
      }
   }
}
```

So our users can do this into their CSS:

```css
.logo {
  background: url('~/static/logo.png');
}
.logo-2 {
  background: url('/logo.png');
}
```

Before this PR, `.logo` background url is transformed to `/static/logo.png` and considered as an url not processed (even if it's starting by an alias), `.logo-2` is not processed and that's perfect.

Aftet this PR, `.logo` is transformed as well and considered to be a relative path (since starting by a known alias) and `.logo-2` is not changed :+1: 

**Does this PR introduce a breaking change?**

No breaking change

Related issue to nuxt.js repo: https://github.com/nuxt/nuxt.js/issues/1435
