### PR TITLE
test: add case for `url` processing

### DIFF
--- a/test/localsTest.js
+++ b/test/localsTest.js
@@ -49,4 +49,11 @@ describe("locals", function() {
 			}
 		}
 	);
+	testLocals("should not fail on processing a url",
+		":local(.abc) { background: url(http://example.com/image.jpg); }",
+		{
+			abc: "_abc"
+		},
+		"?localIdentName=_[local]"
+	);
 });


### PR DESCRIPTION
A regression test follow up to this fix https://github.com/webpack-contrib/css-loader/pull/601

Feel free to ignore/close if it doesn't adhere to your normal test procedures.
