### PR TITLE
docs(README): supplement the use case of `minimize` (`options.minimize`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,16 @@ You can also disable or enforce minification with the `minimize` query parameter
   }
 }
 ```
+or like
+```js
+{
+   test: /\.css$/,
+   use: [
+     'to-string-loader',
+     'css-loader?minimize'
+   ]
+}
+```
 
 ### `sourceMap`
 


### PR DESCRIPTION
Actually we can put `minimize` after `css-loader`.


**What kind of change does this PR introduce?**
Supplement  readme.

**Did you add tests for your changes?**
yup.
**If relevant, did you update the README?**
yup.
**Summary**
I'm searching the usage to put the `minimize` more lightly.

**Does this PR introduce a breaking change?**
Nope.

**Other information**
