### PR TITLE
fix: proper URL escaping and wrapping (`url()`)

### DIFF
--- a/lib/escape-url.js
+++ b/lib/escape-url.js
@@ -1,0 +1,13 @@
+module.exports = function(url) {
+    // If url is already wrapped in quotes, remove them
+    if ((url[0] === '"' || url[0] === '\'') && url[0] === url[url.length - 1]) {
+        url = url.slice(1, -1);
+    }
+    // Should url be wrapped?
+    // See https://drafts.csswg.org/css-values-3/#urls
+    if (/["'() \t\n]/.test(url)) {
+        return '"' + url.replace(/"/g, '\\"').replace(/\n/g, '\\n') + '"'
+    }
+
+    return url
+}

--- a/lib/escape-url.js
+++ b/lib/escape-url.js
@@ -1,6 +1,6 @@
 module.exports = function(url) {
     // If url is already wrapped in quotes, remove them
-    if ((url[0] === '"' || url[0] === '\'') && url[0] === url[url.length - 1]) {
+    if (/^['"].*['"]$/.test(url)) {
         url = url.slice(1, -1);
     }
     // Should url be wrapped?

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -82,10 +82,13 @@ module.exports = function(content, map) {
 				"[" + JSON.stringify(importItem.export) + "] + \"";
 		}
 
-		var escapeUrlHelper;
 		cssAsString = cssAsString.replace(result.importItemRegExpG, importItemMatcher.bind(this));
+
+		// helper for ensuring valid CSS strings from requires
+		var urlEscapeHelper = "";
+
 		if(query.url !== false && result.urlItems.length > 0) {
-			escapeUrlHelper = "var escapeUrl = require(" +
+			urlEscapeHelper = "var escape = require(" +
 				loaderUtils.stringifyRequest(this, require.resolve("./escape-url.js"))
 				+ ")\n"
 
@@ -100,14 +103,12 @@ module.exports = function(content, map) {
 				if(idx > 0) { // idx === 0 is catched by isUrlRequest
 					// in cases like url('webfont.eot?#iefix')
 					urlRequest = url.substr(0, idx);
-					return "\" + escapeUrl(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"" +
+					return "\" + escape(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"" +
 							url.substr(idx);
 				}
 				urlRequest = url;
-				return "\" + escapeUrl(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"";
+				return "\" + escape(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"";
 			}.bind(this));
-		} else {
-			escapeUrlHelper = ""
 		}
 		
 		var exportJs = compileExports(result, importItemMatcher.bind(this), camelCaseKeys);
@@ -133,7 +134,7 @@ module.exports = function(content, map) {
 		}
 
 		// embed runtime
-		callback(null, escapeUrlHelper +
+		callback(null, urlEscapeHelper +
 			"exports = module.exports = require(" +
 			loaderUtils.stringifyRequest(this, require.resolve("./css-base.js")) +
 			")(" + query.sourceMap + ");\n" +

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -88,9 +88,7 @@ module.exports = function(content, map) {
 		var urlEscapeHelper = "";
 
 		if(query.url !== false && result.urlItems.length > 0) {
-			urlEscapeHelper = "var escape = require(" +
-				loaderUtils.stringifyRequest(this, require.resolve("./escape-url.js"))
-				+ ")\n"
+			urlEscapeHelper = "var escape = require(" + loaderUtils.stringifyRequest(this, require.resolve("./url/escape.js")) + ")\n";
 
 			cssAsString = cssAsString.replace(result.urlItemRegExpG, function(item) {
 				var match = result.urlItemRegExp.exec(item);

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -82,8 +82,13 @@ module.exports = function(content, map) {
 				"[" + JSON.stringify(importItem.export) + "] + \"";
 		}
 
+		var escapeUrlHelper;
 		cssAsString = cssAsString.replace(result.importItemRegExpG, importItemMatcher.bind(this));
-		if(query.url !== false) {
+		if(query.url !== false && result.urlItems.length > 0) {
+			escapeUrlHelper = "var escapeUrl = require(" +
+				loaderUtils.stringifyRequest(this, require.resolve("./escape-url.js"))
+				+ ")\n"
+
 			cssAsString = cssAsString.replace(result.urlItemRegExpG, function(item) {
 				var match = result.urlItemRegExp.exec(item);
 				var idx = +match[1];
@@ -95,15 +100,16 @@ module.exports = function(content, map) {
 				if(idx > 0) { // idx === 0 is catched by isUrlRequest
 					// in cases like url('webfont.eot?#iefix')
 					urlRequest = url.substr(0, idx);
-					return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"" +
+					return "\" + escapeUrl(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"" +
 							url.substr(idx);
 				}
 				urlRequest = url;
-				return "\" + require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"";
+				return "\" + escapeUrl(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"";
 			}.bind(this));
+		} else {
+			escapeUrlHelper = ""
 		}
-
-
+		
 		var exportJs = compileExports(result, importItemMatcher.bind(this), camelCaseKeys);
 		if (exportJs) {
 			exportJs = "exports.locals = " + exportJs + ";";
@@ -127,7 +133,8 @@ module.exports = function(content, map) {
 		}
 
 		// embed runtime
-		callback(null, "exports = module.exports = require(" +
+		callback(null, escapeUrlHelper +
+			"exports = module.exports = require(" +
 			loaderUtils.stringifyRequest(this, require.resolve("./css-base.js")) +
 			")(" + query.sourceMap + ");\n" +
 			"// imports\n" +

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -88,7 +88,7 @@ module.exports = function(content, map) {
 		var urlEscapeHelper = "";
 
 		if(query.url !== false && result.urlItems.length > 0) {
-			urlEscapeHelper = "var escape = require(" + loaderUtils.stringifyRequest(this, require.resolve("./url/escape.js")) + ")\n";
+			urlEscapeHelper = "var escape = require(" + loaderUtils.stringifyRequest(this, require.resolve("./url/escape.js")) + ");\n";
 
 			cssAsString = cssAsString.replace(result.urlItemRegExpG, function(item) {
 				var match = result.urlItemRegExp.exec(item);

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -104,10 +104,8 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 					break;
 				case "url":
 					if (options.url && item.url.replace(/\s/g, '').length && !/^#/.test(item.url) && (isAlias(item.url) || loaderUtils.isUrlRequest(item.url, options.root))) {
-						// Don't remove quotes around url when contain space
-						if (item.url.indexOf(" ") === -1) {
-							item.stringType = "";
-						}
+						// Strip quotes, they will be re-added if the module needs them
+						item.stringType = "";
 						delete item.innerSpacingBefore;
 						delete item.innerSpacingAfter;
 						var url = item.url;

--- a/lib/url/escape.js
+++ b/lib/url/escape.js
@@ -1,4 +1,4 @@
-module.exports = function(url) {
+module.exports = function escape(url) {
     // If url is already wrapped in quotes, remove them
     if (/^['"].*['"]$/.test(url)) {
         url = url.slice(1, -1);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,8 +12,8 @@ function getEvaluated(output, modules) {
 		fn(m, m.exports, function(module) {
 			if(module.indexOf("css-base") >= 0)
 				return require("../lib/css-base");
-			if(module.indexOf("escape-url") >= 0)
-				return require("../lib/escape-url");
+			if(module.indexOf("url/escape") >= 0)
+				return require("../lib/url/escape");
 			if(module.indexOf("-!/path/css-loader!") === 0)
 				module = module.substr(19);
 			if(modules && modules[module])

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,6 +12,8 @@ function getEvaluated(output, modules) {
 		fn(m, m.exports, function(module) {
 			if(module.indexOf("css-base") >= 0)
 				return require("../lib/css-base");
+			if(module.indexOf("escape-url") >= 0)
+				return require("../lib/escape-url");
 			if(module.indexOf("-!/path/css-loader!") === 0)
 				module = module.substr(19);
 			if(modules && modules[module])

--- a/test/moduleTestCases/urls/expected.css
+++ b/test/moduleTestCases/urls/expected.css
@@ -2,7 +2,7 @@
 	background: url({./module});
 	background: url({./module});
 	background: url("{./module module}");
-	background: url('{./module module}');
+	background: url("{./module module}");
 	background: url({./module});
 	background: url({./module}#?iefix);
 	background: url("#hash");

--- a/test/urlTest.js
+++ b/test/urlTest.js
@@ -103,6 +103,25 @@ describe("url", function() {
 	test("external schema-less url", ".class { background: green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz }", [
 		[1, ".class { background: green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz }", ""]
 	]);
+	
+	test("module wrapped in spaces", ".class { background: green url(module) xyz }", [
+		[1, ".class { background: green url(module-wrapped) xyz }", ""]
+	], "", { './module': "\"module-wrapped\"" });
+	test("module with space", ".class { background: green url(module) xyz }", [
+		[1, ".class { background: green url(\"module with space\") xyz }", ""]
+	], "", { './module': "module with space" });
+	test("module with quote", ".class { background: green url(module) xyz }", [
+		[1, ".class { background: green url(\"module\\\"with\\\"quote\") xyz }", ""]
+	], "", { './module': "module\"with\"quote" });
+	test("module with quote wrapped", ".class { background: green url(module) xyz }", [
+		[1, ".class { background: green url(\"module\\\"with\\\"quote\\\"wrapped\") xyz }", ""]
+	], "", { './module': "\"module\"with\"quote\"wrapped\"" });
+	test("module with parens", ".class { background: green url(module) xyz }", [
+		[1, ".class { background: green url(\"module(with-parens)\") xyz }", ""]
+	], "", { './module': 'module(with-parens)' });
+	test("module with newline", ".class { background: green url(module) xyz }", [
+		[1, ".class { background: green url(\"module\\nwith\\nnewline\") xyz }", ""]
+	], "", { './module': "module\nwith\nnewline" });
 
 	test("background img with url", ".class { background: green url( \"img.png\" ) xyz }", [
 		[1, ".class { background: green url( \"img.png\" ) xyz }", ""]

--- a/test/urlTest.js
+++ b/test/urlTest.js
@@ -122,6 +122,9 @@ describe("url", function() {
 	test("module with newline", ".class { background: green url(module) xyz }", [
 		[1, ".class { background: green url(\"module\\nwith\\nnewline\") xyz }", ""]
 	], "", { './module': "module\nwith\nnewline" });
+	test("module from url-loader", ".class { background: green url(module) xyz }", [
+		[1, ".class { background: green url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA) xyz }", ""]
+	], "", { './module': "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA" });
 
 	test("background img with url", ".class { background: green url( \"img.png\" ) xyz }", [
 		[1, ".class { background: green url( \"img.png\" ) xyz }", ""]

--- a/test/urlTest.js
+++ b/test/urlTest.js
@@ -19,7 +19,7 @@ describe("url", function() {
 		[1, ".class { background: green url(\"{./img img.png}\") xyz }", ""]
 	]);
 	test("background 2 img contain space in name", ".class { background: green url( 'img img.png' ) xyz }", [
-		[1, ".class { background: green url('{./img img.png}') xyz }", ""]
+		[1, ".class { background: green url(\"{./img img.png}\") xyz }", ""]
 	]);
 	test("background img absolute", ".class { background: green url(/img.png) xyz }", [
 		[1, ".class { background: green url(/img.png) xyz }", ""]


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
Yes. 2 existing tests changed to account for new behaviour (no single-quotes), 6 new tests of escaping.

**If relevant, did you update the README?**
I don't believe it's relevant. Unless just to document the quoting behaviour.

**Summary**
Fixes #615. Previously, modules had their quotes stripped unless the module-path contained a space. Now, quotes are always stripped and the URL returned from the module is escaped and wrapped in double-quotes if necessary. Modules returning a quote-wrapped string will have their own wrapping-quotes stripped before wrapping/escaping.

**Does this PR introduce a breaking change?**
I don't think it does, modules wrapping in quotes like svg-url-loader should still function.

The only consequence is that it is impossible to wrap in single-quotes, although it's hard to see when this would be a necessity.

**Other information**
There is one weird case I'm not sure how to handle: newlines should be escaped in the quoted url. [The spec states](https://www.w3.org/TR/css-syntax/#newline) that only line feeds (`\n`) count as newlines, since carriage return (`\r`) and form feed (`\f`) are automatically converted during preprocessing. However, if left unescaped they would be converted to unescaped line feeds. If escaped, they wouldn't be converted. I'm not sure if the best step would be to convert them to escaped line feeds manually or if it even matters. Thoughts?