### PR TITLE
feat: add IE filter support (`AlphaImageLoader`)

### DIFF
--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -100,7 +100,7 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 					if (item.name.indexOf('progid:DXImageTransform.Microsoft.AlphaImageLoader') >= 0){
 						delete item.innerSpacingBefore;
 						delete item.innerSpacingAfter;
-						var matchSrc = item.name.match(/src=[\'\"]([^\'\"]+)[\'\"]/);
+						var matchSrc = item.name.match(/src=['"]([^'"]+)['"]/);
 						if (!matchSrc) break;
 						var srcUrl = matchSrc[1];
 						if (options.url && !/^#/.test(srcUrl) && (isAlias(srcUrl) || loaderUtils.isUrlRequest(srcUrl, options.root))) {

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -97,6 +97,20 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 					item.nodes.forEach(processNode);
 					break;
 				case "item":
+					if (item.name.indexOf('progid:DXImageTransform.Microsoft.AlphaImageLoader') >= 0){
+						delete item.innerSpacingBefore;
+						delete item.innerSpacingAfter;
+						var matchSrc = item.name.match(/src=[\'\"]([^\'\"]+)[\'\"]/);
+						if (!matchSrc) break;
+						var srcUrl = matchSrc[1];
+						if (options.url && !/^#/.test(srcUrl) && (isAlias(srcUrl) || loaderUtils.isUrlRequest(srcUrl, options.root))) {
+							item.name = item.name.replace(srcUrl, "___CSS_LOADER_URL___" + urlItems.length + "___");
+							urlItems.push({
+								url: srcUrl
+							});
+						}
+						break;
+					}
 					var importIndex = imports["$" + item.name];
 					if (typeof importIndex === "number") {
 						item.name = "___CSS_LOADER_IMPORT___" + importIndex + "___";

--- a/test/urlTest.js
+++ b/test/urlTest.js
@@ -189,4 +189,12 @@ describe("url", function() {
 	test("external schema-less url", ".class { background: green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz }", [
 		[1, ".class { background: green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz }", ""]
 	], "?-url");
+	test("filter ie AlphaImageLoader ",
+		".highlight { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src=\"http://example.com/image.jpg\", sizingMethod='scale'); }", [
+		[1, ".highlight { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src=\"http://example.com/image.jpg\", sizingMethod='scale'); }", ""]
+	], "?-url");
+	test("filter ie AlphaImageLoader relativePath",
+		".highlight { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src=\"./image.png\", sizingMethod='scale'); }", [
+		[1, ".highlight { filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src=\"./image.png\", sizingMethod='scale'); }", ""]
+	], "?-url");
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
support ie filter.

since IE not supprt background-size. we usually use filter to polyfill background image;
`
        background: url('../images/home@1x.png') no-repeat center;
        background-size: 100% 100%;
        filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='../images/home@1x.png', sizingMethod='scale');
`

**If relevant, did you update the README?**

**Summary**
for css-loader to support ie filter

**Does this PR introduce a breaking change?**
No

**Other information**