### PR TITLE
fix(loader): correctly check if source map is `undefined`

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -110,7 +110,7 @@ module.exports = function(content, map) {
 		}
 
 		var moduleJs;
-		if(query.sourceMap && result.map) {
+		if(sourceMap && result.map) {
 			// add a SourceMap
 			map = result.map;
 			if(map.sources) {
@@ -129,7 +129,7 @@ module.exports = function(content, map) {
 		// embed runtime
 		callback(null, "exports = module.exports = require(" +
 			loaderUtils.stringifyRequest(this, require.resolve("./css-base.js")) +
-			")(" + query.sourceMap + ");\n" +
+			")(" + sourceMap + ");\n" +
 			"// imports\n" +
 			importJs + "\n\n" +
 			"// module\n" +


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

bugfix

**Did you add tests for your changes?**

not required

**If relevant, did you update the README?**

not required

**Summary**

When `sourceMap` not specify we get `exports = module.exports = require("../node_modules/css-loader/lib/css-base.js")(undefined);` here https://github.com/webpack-contrib/css-loader/blob/master/lib/loader.js#L132

**Does this PR introduce a breaking change?**

No

**Other information**
