### PR TITLE
Update importLoaders documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ The query parameter `importLoaders` allows to configure how many loaders before 
     {
       loader: 'css-loader',
       options: {
-        importLoaders: 1 // 0 => no loaders (default); 1 => postcss-loader; 2 => postcss-loader, sass-loader
+        importLoaders: 2 // 0 => no loaders (default); 1 => postcss-loader; 2 => postcss-loader, sass-loader
       }
     },
     'postcss-loader',


### PR DESCRIPTION
This is just a small update to the README. I've spent some time trying to understand how to properly configure the `importLoaders` option, and it seems like this number should always be the number of loaders that precede the the `css-loader`. If my understanding is correct, it would make sense to update this example. Otherwise, I think we should add some more documentation here to describe how to choose this number. I would be happy to update this PR with that documentation if someone could give me some more context on what's expected here. Thanks!