### PR TITLE
fix: ignore invalid URLs (`url()`)

### DIFF
--- a/lib/url/escape.js
+++ b/lib/url/escape.js
@@ -1,4 +1,7 @@
 module.exports = function escape(url) {
+    if (typeof url !== 'string') {
+        return url
+    }
     // If url is already wrapped in quotes, remove them
     if (/^['"].*['"]$/.test(url)) {
         url = url.slice(1, -1);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -16,7 +16,7 @@ function getEvaluated(output, modules) {
 				return require("../lib/url/escape");
 			if(module.indexOf("-!/path/css-loader!") === 0)
 				module = module.substr(19);
-			if(modules && modules[module])
+			if(modules && module in modules)
 				return modules[module];
 			return "{" + module + "}";
 		});

--- a/test/urlTest.js
+++ b/test/urlTest.js
@@ -125,6 +125,12 @@ describe("url", function() {
 	test("module from url-loader", ".class { background: green url(module) xyz }", [
 		[1, ".class { background: green url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA) xyz }", ""]
 	], "", { './module': "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA" });
+	test("module from null-loader (empty object from webpack)", ".class { background: green url(module) xyz }", [
+		[1, ".class { background: green url([object Object]) xyz }", ""]
+	], "", { './module': {} });
+	test("module is null", ".class { background: green url(module) xyz }", [
+		[1, ".class { background: green url(null) xyz }", ""]
+	], "", { './module': null });
 
 	test("background img with url", ".class { background: green url( \"img.png\" ) xyz }", [
 		[1, ".class { background: green url( \"img.png\" ) xyz }", ""]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Closes #659

**Did you add tests for your changes?**
Test added for dependency exporting an empty object and null.

**If relevant, did you update the README?**
Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

https://github.com/webpack-contrib/css-loader/pull/627 introduced an assumption about all dependencies exporting strings. To avoid including font-files, some users use `null-loader`, which effectively exports an empty object.

This PR checks for non-strings, restoring previous functionality for all non-string dependencies.

While this PR would enable previous usage patterns, I hope someone can come up with a better solution. The users are relying on `url([object Object])` being invalid CSS to avoid making requests for font files. This seems fragile in the long run.

Ideally, a null/undefined value (or what we here know *should* be a null value, `{}`) should result in no request being made. As far as I know, this requires the entire `url(...)` block be replaced with `none`, and I'm still not sure this would be valid at all times. This would be a complicated solution.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.