### PR TITLE
fix(css-base): use `content_` instead of `content` (#674)

### DIFF
--- a/lib/css-base.js
+++ b/lib/css-base.js
@@ -48,10 +48,10 @@ module.exports = function(useSourceMap) {
 };
 
 function cssWithMappingToString(item, useSourceMap) {
-	var content = item[1] || '';
+	var content_ = item[1] || '';
 	var cssMapping = item[3];
 	if (!cssMapping) {
-		return content;
+		return content_;
 	}
 
 	if (useSourceMap && typeof btoa === 'function') {
@@ -60,10 +60,10 @@ function cssWithMappingToString(item, useSourceMap) {
 			return '/*# sourceURL=' + cssMapping.sourceRoot + source + ' */'
 		});
 
-		return [content].concat(sourceURLs).concat([sourceMapping]).join('\n');
+		return [content_].concat(sourceURLs).concat([sourceMapping]).join('\n');
 	}
 
-	return [content].join('\n');
+	return [content_].join('\n');
 }
 
 // Adapted from convert-source-map (MIT)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No, there isn't any new functionality.

**If relevant, did you update the README?**
Not relevant.

**Summary**
When using the library in WebSphere Portal within a ScriptPortlet, it throws an exception because the name of a local variable (inside a function) is a reserved word in the WCM of WebSphere Portal. This is the reported issue:
[#674](https://github.com/webpack-contrib/css-loader/issues/674)


**Does this PR introduce a breaking change?**
No, since it's a local variable.

**Other information**
