### PR TITLE
fix(getLocalIdent): add `rootContext` support (`webpack >= v4.0.0`)

### DIFF
--- a/lib/getLocalIdent.js
+++ b/lib/getLocalIdent.js
@@ -6,7 +6,7 @@ var loaderUtils = require("loader-utils");
 var path = require("path");
 
 module.exports = function getLocalIdent(loaderContext, localIdentName, localName, options) {
-	if(!options.context)
+	if(!options.context) {
 		if (loaderContext.rootContext) {
 			options.context = loaderContext.rootContext;
 		} else if (loaderContext.options && typeof loaderContext.options.context === "string") {
@@ -14,6 +14,7 @@ module.exports = function getLocalIdent(loaderContext, localIdentName, localName
 		} else {
 			options.context = loaderContext.context;
 		}
+	}
 	var request = path.relative(options.context, loaderContext.resourcePath);
 	options.content = options.hashPrefix + request + "+" + localName;
 	localIdentName = localIdentName.replace(/\[local\]/gi, localName);

--- a/lib/getLocalIdent.js
+++ b/lib/getLocalIdent.js
@@ -7,7 +7,13 @@ var path = require("path");
 
 module.exports = function getLocalIdent(loaderContext, localIdentName, localName, options) {
 	if(!options.context)
-		options.context = loaderContext.options && typeof loaderContext.options.context === "string" ? loaderContext.options.context : loaderContext.context;
+		if (loaderContext.rootContext) {
+			options.context = loaderContext.rootContext;
+		} else if (loaderContext.options && typeof loaderContext.options.context === "string") {
+			options.context = loaderContext.options.context;
+		} else {
+			options.context = loaderContext.context;
+		}
 	var request = path.relative(options.context, loaderContext.resourcePath);
 	options.content = options.hashPrefix + request + "+" + localName;
 	localIdentName = localIdentName.replace(/\[local\]/gi, localName);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix.

**Did you add tests for your changes?**
No, because this project doesn't have e2e tests to test such case.

**Summary**
This PR fixes the behavior of `getLocalIdent`, which cause bugs with webpack 4.
[According to the chanelog](https://github.com/webpack/webpack/releases/tag/v4.0.0-beta.0), the `rootContext ` was added.  Loaders may use it to make stuff relative to the application root.

Also, `loaderContext.options` was removed, so the `options.context` is always value from `loaderContext.context`, which is actually filename without path.

So for example, if we have `a/a.css` and `b/a.css` both with `.c {}` content, the hash will be generated according to the `a.css` and `c` values (the same for these 2 independent files), which will cause class name conflicts.

Previous webpack versions don't include `loaderContext.rootContext` and as a result, this change is fully compatible with previous webpack versions and won't break anything.

**Does this PR introduce a breaking change?**
No

**Other information**
