### PR TITLE
feat: add `resultHook` (`options.resultHook`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ It's useful when you, for instance, need to post process the CSS as a string.
 |**[`camelCase`](#camelcase)**|`{Boolean\|String}`|`false`|Export Classnames in CamelCase|
 |**[`importLoaders`](#importloaders)**|`{Number}`|`0`|Number of loaders applied before CSS loader|
 |**`localIdentName`**|`{String}`|`[hash:base64]`|Configure the generated ident|
+|**[`resultHook`](#resulthook)**|`{Function}`|`undefined`|CSS process result callback|
 
 ### `root`
 
@@ -429,6 +430,28 @@ The query parameter `importLoaders` allows to configure how many loaders before 
 ```
 
 This may change in the future, when the module system (i. e. webpack) supports loader matching by origin.
+
+### `resultHook`
+
+The query parameter `resultHook` allows passing callback that will be called when the loader gets the result for a file.
+
+**webpack.config.js**
+```js
+{
+  test: /\.css$/,
+  use: [
+    'style-loader',
+    {
+      loader: 'css-loader',
+      options: {
+        resultHook: function(loaderContext, result) { /* Process the result */ }
+      }
+    },
+    'postcss-loader',
+    'sass-loader'
+  ]
+}
+```
 
 <h2 align="center">Examples</h2>
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -18,6 +18,7 @@ module.exports = function(content, map) {
 	var camelCaseKeys = query.camelCase || query.camelcase;
 	var sourceMap = query.sourceMap || false;
 	var resolve = createResolver(query.alias);
+	var resultHook = query.resultHook;
 
 	if(sourceMap) {
 		if (map) {
@@ -45,7 +46,8 @@ module.exports = function(content, map) {
 		resolve: resolve,
 		minimize: this.minimize,
 		loaderContext: this,
-		sourceMap: sourceMap
+		sourceMap: sourceMap,
+		resultHook: resultHook
 	}, function(err, result) {
 		if(err) return callback(err);
 

--- a/lib/localsLoader.js
+++ b/lib/localsLoader.js
@@ -16,13 +16,15 @@ module.exports = function(content) {
 	var moduleMode = query.modules || query.module;
 	var camelCaseKeys = query.camelCase || query.camelcase;
 	var resolve = createResolver(query.alias);
+	var resultHook = query.resultHook;
 
 	processCss(content, null, {
 		mode: moduleMode ? "local" : "global",
 		query: query,
 		minimize: this.minimize,
 		loaderContext: this,
-		resolve: resolve
+		resolve: resolve,
+		resultHook: resultHook
 	}, function(err, result) {
 		if(err) return callback(err);
 

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -208,7 +208,7 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 			annotation: false
 		} : null
 	}).then(function(result) {
-		callback(null, {
+		var callbackResult = {
 			source: result.css,
 			map: result.map && result.map.toJSON(),
 			exports: parserOptions.exports,
@@ -218,7 +218,13 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 			urlItems: parserOptions.urlItems,
 			urlItemRegExpG: /___CSS_LOADER_URL___([0-9]+)___/g,
 			urlItemRegExp: /___CSS_LOADER_URL___([0-9]+)___/
-		});
+		};
+
+		if (options.resultHook) {
+			options.resultHook(options.loaderContext, callbackResult);
+		}
+
+		callback(null, callbackResult);
 	}).catch(function(err) {
 		if (err.name === 'CssSyntaxError') {
 			var wrappedError = new CSSLoaderError(

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -2091,6 +2100,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -2246,6 +2261,12 @@
         "lodash._isiterateecall": "3.0.9"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -2297,6 +2318,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lolex": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -2495,6 +2522,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.6.tgz",
+      "integrity": "sha512-ewMXDEflamPfDbh7y08tbrJCAiN87SEz388s2cG4ODYnA+ge6QB8pvjo+Pkv9844qMB+NPE9O8tMyIEle0vyew==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.3.2",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      }
     },
     "nopt": {
       "version": "3.0.6",
@@ -2711,6 +2751,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "1.1.0",
@@ -3607,6 +3664,12 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -3709,6 +3772,38 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
+      "integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.2",
+        "nise": "1.2.6",
+        "supports-color": "5.2.0",
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -4113,6 +4208,12 @@
         "rimraf": "2.1.4"
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "text-extensions": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
@@ -4186,6 +4287,12 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "should": "^11.1.2",
+    "sinon": "^4.4.2",
     "standard-version": "^4.0.0"
   },
   "scripts": {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,6 +4,7 @@ require("should");
 var cssLoader = require("../index.js");
 var cssLoaderLocals = require("../locals.js");
 var vm = require("vm");
+var sinon = require("sinon");
 
 function getEvaluated(output, modules) {
 	try {
@@ -168,3 +169,20 @@ exports.testMinimize = function testMinimize(name, input, result, query, modules
 		});
 	});
 };
+
+exports.testResultHook = function testResultHook(name, loader) {
+	it(name, function(done) {
+		var source = "div { color: red; }";
+		var resultHook = sinon.spy();
+		runLoader(loader, source, undefined, {
+			query: { resultHook: resultHook }
+		}, function(err) {
+			if(err) return done(err);
+			resultHook.called.should.be.eql(true);
+			var hookArgs = resultHook.args[0];
+			hookArgs[0].request.should.be.eql("css-loader!test.css");
+			hookArgs[1].source.should.be.eql(source);
+			done();
+		});
+	});
+}

--- a/test/resultHookTest.js
+++ b/test/resultHookTest.js
@@ -1,0 +1,11 @@
+/*globals describe */
+
+require("should");
+var testResultHook = require("./helpers").testResultHook;
+var cssLoader = require("../index.js");
+var cssLoaderLocals = require("../locals.js");
+
+describe("resultHook", function() {
+	testResultHook("calls resultHook with the loader context and the result", cssLoader);
+	testResultHook("works with the locals loader", cssLoaderLocals);
+});


### PR DESCRIPTION
When resultHook is passed with the query, css-loader will call it with the loader context and the result. It will allow extending css-loader functionality without using a fork. For instance, it will be possible to generate TypeScript typing files on the fly.

**What kind of change does this PR introduce?**
This PR introduces a feature.

**Did you add tests for your changes?**
Yes.

**If relevant, did you update the README?**
Yes.

**Summary**
I want to add TypeScript support to [decss](https://github.com/kossnocorp/decss). To do so I have to generate type definition files. I can't do it via additional loader as I need an access to raw exports object.

**Does this PR introduce a breaking change?**
Nope.

**Other information**
¯\\_(ツ)_/¯
