### PR TITLE
[WIP] feat(loader): disable `@import` resolving (`options.import`)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -65,7 +65,7 @@ module.exports = function(content, map) {
 		}).map(function(imp) {
 			if(!loaderUtils.isUrlRequest(imp.url, root)) {
 				return "exports.push([module.id, " +
-					JSON.stringify("@import url(" + imp.url + ");") + ", " +
+					JSON.stringify((query.import ? "" : "/*!\n") + "@import url(" + imp.url + ");" + (query.import ? "" : "\n*/")) + ", " +
 					JSON.stringify(imp.mediaQuery) + "]);";
 			} else {
 				var importUrl = importUrlPrefix + imp.url;

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -41,7 +41,7 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 			return str;
 		}
 
-		if(options.import) {
+		//if(options.import) {
 			css.walkAtRules(/^import$/i, function(rule) {
 				var values = Tokenizer.parseValues(rule.params);
 				var url = values.nodes[0].nodes[0];
@@ -64,7 +64,7 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 				});
 				rule.remove();
 			});
-		}
+		//}
 
 		var icss = icssUtils.extractICSS(css);
 		exports = icss.icssExports;


### PR DESCRIPTION
…, set `@import url('https://fonts.googleapis.com/css?family=Roboto');` to empty

**What kind of change does this PR introduce?**
A bugfix

**Did you add tests for your changes?**
Yes
```js
                {
                    test: /\.css$/,
                    use: ExtractTextPlugin.extract({
                        fallback: 'style-loader',
                        use: [
                            {
                                loader: 'css-loader',
                                options: {
                                    minimize: {
                                        discardComments: {
                                            removeAll: true,
                                        },
                                    },
                                    import: false,
                                    importLoaders: 1,
                                },
                            },
                            'postcss-loader',
                        ],
                    }),
                },
```

**If relevant, did you update the README?**
NONE

**Summary**
 https://github.com/webpack-contrib/css-loader#import DOES NOT WORK for css

**Does this PR introduce a breaking change?**
No

**Other information**
