### PR TITLE
fix(lib/processCss): don't check `mode` for `url` handling (`options.modules`)

### DIFF
--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -55,9 +55,11 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 				}
 				values.nodes[0].nodes.shift();
 				var mediaQuery = Tokenizer.stringifyValues(values);
-				if(loaderUtils.isUrlRequest(url, options.root) && options.mode === "global") {
+
+				if(loaderUtils.isUrlRequest(url, options.root)) {
 					url = loaderUtils.urlToRequest(url, options.root);
 				}
+
 				importItems.push({
 					url: url,
 					mediaQuery: mediaQuery


### PR DESCRIPTION
### `Issues`

- Fixes #697 

### `Notable Changes`

Removes the check for  'Module Mode'  (`local || global`) when resolving import URLs as it seems to be unneeded (?)