### PR TITLE
Allow query.getCssModuleMapping to get at css module classes at buildtime

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -108,9 +108,14 @@ module.exports = function(content, map) {
 				return "\" + escape(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"";
 			}.bind(this));
 		}
-		
+
+
 		var exportJs = compileExports(result, importItemMatcher.bind(this), camelCaseKeys);
 		if (exportJs) {
+			if (typeof query.getCssModuleMapping === "function") {
+				var fileName = loaderUtils.getRemainingRequest(this).split("!").pop()
+				query.getCssModuleMapping(fileName, result.exports)
+			}
 			exportJs = "exports.locals = " + exportJs + ";";
 		}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature.

**Did you add tests for your changes?**

No, because I'd first like to get feedback on this idea - but I am happy to write tests :)

**If relevant, did you update the README?**

Again, no because I'd like to get a sense on if this PR will get merged. If you're open to merging it then yes I'll update the PR with docs.

**Summary**

The motivation here is that alongside importing our CSS modules in JS, we'd also like to write a `css-modules.json` file that we'll use for some tooling. Therefore, we wanted to maintain the behaviour of being able to write `import styles from '..'`, and get an object back, but also we wanted to hook into the build to get access at build time to the map of classes.

This PR introduces `getCssModuleMapping` which is called with the source file, and the map of classes, so that as a consumer I can hook into this and do anything I want with these files.

**Does this PR introduce a breaking change?**

No.

**Other information**
