### PR TITLE
chore(package): drop Node.js 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 branches:
   only:
@@ -7,25 +6,14 @@ matrix:
   fast_finish: true
   include:
     - os: linux
-      node_js: "7"
-      env: WEBPACK_VERSION="2.2.0" JOB_PART=lint
+      node_js: "10"
+    - os: linux
+      node_js: "8"
     - os: linux
       node_js: "6"
-      env: WEBPACK_VERSION="2.2.0" JOB_PART=test
-    - os: linux
-      node_js: "4.3"
-      env: WEBPACK_VERSION="2.2.0" JOB_PART=test
-    - os: linux
-      node_js: "7"
-      env: WEBPACK_VERSION="2.2.0" JOB_PART=test
-    - os: linux
-      node_js: "4.3"
-      env: WEBPACK_VERSION="1.14.0" JOB_PART=test
 before_install:
   - nvm --version
   - node --version
-before_script:
-  - 'if [ "$WEBPACK_VERSION" ]; then npm i webpack@^$WEBPACK_VERSION; fi'
 script:
   - npm run travis:$JOB_PART
 after_success:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no relevant

**If relevant, did you update the README?**

no relevant

**Summary**

Nodde.js 4 has no security updates and was dropped a few Webpack versions ago. It is safe to drop this support.

We need it for cssnano 4 update https://github.com/webpack-contrib/css-loader/pull/739

But I do not really force this changes. If there is a reason why we can’t drop Node.js 4 support, we can found another way.

**Does this PR introduce a breaking change?**
 
yes
