### PR TITLE
fix(lib/loader): correctly wrap `url`'s containing anchors

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -95,8 +95,8 @@ module.exports = function(content, map) {
 				if(idx > 0) { // idx === 0 is catched by isUrlRequest
 					// in cases like url('webfont.eot?#iefix')
 					urlRequest = url.substr(0, idx);
-					return "\" + escape(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"" +
-							url.substr(idx);
+					return "\" + escape(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ") + \"" +
+					url.substr(idx) + "\") + \"";
 				}
 				urlRequest = url;
 				return "\" + escape(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"";

--- a/test/urlTest.js
+++ b/test/urlTest.js
@@ -172,6 +172,9 @@ describe("url", function() {
 	test("font face with url", "@font-face { src: url(regular.woff) format('woff'), url(~truetype/regular.ttf) format('truetype') }", [
 		[1, "@font-face { src: url(regular.woff) format('woff'), url(~truetype/regular.ttf) format('truetype') }", ""]
 	], "?-url");
+	test("font face with url", '@font-face { src: url("bold regular.woff?#iefix") format("woff") }', [
+		[1, '@font-face { src: url("{./bold regular.woff}?#iefix") format("woff") }', ""]
+	], "", { './module': "data:font/ttf;base64,AAEAAAATAQAABAAwR1BPU+Df" });
 	test("font face with url", "@font-face { src: url(Mark Simonson - Proxima Nova Alt Regular-webfont.eot?#iefix) format('embedded-opentype'), url(~opentype/Mark Simonson - Proxima Nova Alt Regular-webfont.eot?#iefix) format('embedded-opentype') }", [
 		[1, "@font-face { src: url(Mark Simonson - Proxima Nova Alt Regular-webfont.eot?#iefix) format('embedded-opentype'), url(~opentype/Mark Simonson - Proxima Nova Alt Regular-webfont.eot?#iefix) format('embedded-opentype') }", ""]
 	], "?-url");


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
YES

**If relevant, did you update the README?**
no need

**Summary**

```
@font-face {
  font-family: 'Jason Web';
  src: url("jason-font.eot");
  src: url("jason-font.eot?#iefix") format("embedded-opentype");
}
```
is compiled to
```
@font-face {
  font-family: 'Jason Web';
  src: url("jason-font.eot");
  src: url("jason-font.eot"?#iefix) format("embedded-opentype");
}
```

In the url:  `"jason-font.eot"?#iefix`, the last quote should before the brace.

**Does this PR introduce a breaking change?**
NO

**Other information**
