### PR TITLE
feat(loader): add `exclude` option (`options.exclude`)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -8,14 +8,17 @@ var getImportPrefix = require("./getImportPrefix");
 var compileExports = require("./compile-exports");
 
 
-module.exports = function(content, map) {
+module.exports = function (content, map) {
 	var callback = this.async();
 	var query = loaderUtils.getOptions(this) || {};
 	var moduleMode = query.modules;
 	var camelCaseKeys = query.camelCase;
 	var sourceMap = query.sourceMap || false;
+	var exclude = query.exclude;
+	var from = loaderUtils.getRemainingRequest(this).split("!").pop();
+	var to = loaderUtils.getCurrentRequest(this).split("!").pop();
 
-	if(sourceMap) {
+	if (sourceMap) {
 		if (map) {
 			if (typeof map === "string") {
 				map = JSON.stringify(map);
@@ -33,15 +36,34 @@ module.exports = function(content, map) {
 		map = null;
 	}
 
+	function isExclude(path) {
+		if (from.indexOf(path) === 0) {
+			return true;
+		}
+		return false;
+	}
+
+	if (Array.isArray(exclude)) {
+		exclude.forEach(function (p) {
+			if (isExclude(p)) {
+				moduleMode = false;
+			}
+		});
+	} else if (typeof exclude === 'string') {
+		if (isExclude(exclude)) {
+			moduleMode = false;
+		}
+	}
+
 	processCss(content, map, {
 		mode: moduleMode ? "local" : "global",
-		from: loaderUtils.getRemainingRequest(this).split("!").pop(),
-		to: loaderUtils.getCurrentRequest(this).split("!").pop(),
+		from: from,
+		to: to,
 		query: query,
 		loaderContext: this,
 		sourceMap: sourceMap
-	}, function(err, result) {
-		if(err) return callback(err);
+	}, function (err, result) {
+		if (err) return callback(err);
 
 		var cssAsString = JSON.stringify(result.source);
 
@@ -49,15 +71,15 @@ module.exports = function(content, map) {
 		var importUrlPrefix = getImportPrefix(this, query);
 
 		var alreadyImported = {};
-		var importJs = result.importItems.filter(function(imp) {
-			if(!imp.mediaQuery) {
-				if(alreadyImported[imp.url])
+		var importJs = result.importItems.filter(function (imp) {
+			if (!imp.mediaQuery) {
+				if (alreadyImported[imp.url])
 					return false;
 				alreadyImported[imp.url] = true;
 			}
 			return true;
-		}).map(function(imp) {
-			if(!loaderUtils.isUrlRequest(imp.url)) {
+		}).map(function (imp) {
+			if (!loaderUtils.isUrlRequest(imp.url)) {
 				return "exports.push([module.id, " +
 					JSON.stringify("@import url(" + imp.url + ");") + ", " +
 					JSON.stringify(imp.mediaQuery) + "]);";
@@ -81,22 +103,22 @@ module.exports = function(content, map) {
 		// helper for ensuring valid CSS strings from requires
 		var urlEscapeHelper = "";
 
-		if(query.url !== false && result.urlItems.length > 0) {
+		if (query.url !== false && result.urlItems.length > 0) {
 			urlEscapeHelper = "var escape = require(" + loaderUtils.stringifyRequest(this, require.resolve("./url/escape.js")) + ");\n";
 
-			cssAsString = cssAsString.replace(result.urlItemRegExpG, function(item) {
+			cssAsString = cssAsString.replace(result.urlItemRegExpG, function (item) {
 				var match = result.urlItemRegExp.exec(item);
 				var idx = +match[1];
 				var urlItem = result.urlItems[idx];
 				var url = urlItem.url;
 				idx = url.indexOf("?#");
-				if(idx < 0) idx = url.indexOf("#");
+				if (idx < 0) idx = url.indexOf("#");
 				var urlRequest;
-				if(idx > 0) { // idx === 0 is catched by isUrlRequest
+				if (idx > 0) { // idx === 0 is catched by isUrlRequest
 					// in cases like url('webfont.eot?#iefix')
 					urlRequest = url.substr(0, idx);
 					return "\" + escape(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"" +
-							url.substr(idx);
+						url.substr(idx);
 				}
 				urlRequest = url;
 				return "\" + escape(require(" + loaderUtils.stringifyRequest(this, urlRequest) + ")) + \"";
@@ -109,11 +131,11 @@ module.exports = function(content, map) {
 		}
 
 		var moduleJs;
-		if(sourceMap && result.map) {
+		if (sourceMap && result.map) {
 			// add a SourceMap
 			map = result.map;
-			if(map.sources) {
-				map.sources = map.sources.map(function(source) {
+			if (map.sources) {
+				map.sources = map.sources.map(function (source) {
 					return source.split("!").pop().replace(/\\/g, '/');
 				}, this);
 				map.sourceRoot = "";


### PR DESCRIPTION
When I set `modules` to `true`, I want to ignore certain files, but I need to use these loaders again. I have no way to find a solution.

For example, my project uses `monaco-editor`, `monaco-editor` uses the import method in the component to load `css`, but it does not use the method like `react -> className` to set the class.

so I have to change it myself

add `exclude` to `options`

**webpack.config**
```
{
    test: /\.css$/,
    use: [
        {
            loader: 'style-loader'
        },
        {
            loader: 'css-loader',
            options: {
                modules: true,
                importLoaders: 1,
                localIdentName: '[name]_[local]',
                camelCase: true,
                exclude: [
                    path.resolve(__dirname, 'node_modules/monaco-editor')
                ]
            }
        },
        {
            loader: 'postcss-loader',
            options: {
                ident: 'postcss',
                plugins: function () {
                    return [
                        postcssImport,
                        postcssVars,
                        autoprefixer({
                            browsers: ['last 3 versions', 'Safari >= 8', 'iOS >= 8']
                        })
                    ];
                }
            }
        }
    ]
}
```

**Hope to adopt, thx**