### PR TITLE
docs(readme): add an example how to `@import` a node module

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,16 @@ url(~module/image.png) => require('module/image.png')
 
 ### `import`
 
+To import styles from a node module path, prefix it with a `~`:
+
+```css
+@import '~module/styles.css';
+```
+
 To disable `@import` resolving by `css-loader` set the option to `false`
 
 ```css
 @import url('https://fonts.googleapis.com/css?family=Roboto');
-@import '~module/styles.css';
 ```
 
 > _⚠️ Use with caution, since this disables resolving for **all** `@import`s, including css modules `composes: xxx from 'path/to/file.css'` feature._

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ To disable `@import` resolving by `css-loader` set the option to `false`
 
 ```css
 @import url('https://fonts.googleapis.com/css?family=Roboto');
+@import '~module/styles.css';
 ```
 
 > _⚠️ Use with caution, since this disables resolving for **all** `@import`s, including css modules `composes: xxx from 'path/to/file.css'` feature._


### PR DESCRIPTION
The syntax for importing a node module is not easy to find (see https://github.com/webpack/webpack/issues/1789#issuecomment-277024235). Maybe this will help a few people out.


**What kind of change does this PR introduce?**
Dcoumentation