### PR TITLE
fix(loader): trim unquoted import urls

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -49,7 +49,11 @@ module.exports = function(content, map) {
 		var importUrlPrefix = getImportPrefix(this, query);
 
 		var alreadyImported = {};
-		var importJs = result.importItems.filter(function(imp) {
+		var importJs = result.importItems.map(function(imp) {
+			// fixes #781 when importing `url(filename.css )`
+			imp.url = imp.url.trim();
+			return imp;
+		}).filter(function(imp) {
 			if(!imp.mediaQuery) {
 				if(alreadyImported[imp.url])
 					return false;

--- a/test/importTest.js
+++ b/test/importTest.js
@@ -13,6 +13,12 @@ describe("import", function() {
 	], "", {
 		"./test.css": [[2, ".test{a: b}", ""]]
 	});
+	test("import with trailing whitespace", "@import url(test.css );\n.class { a: b c d; }", [
+		[2, ".test{a: b}", ""],
+		[1, ".class { a: b c d; }", ""]
+	], "", {
+		"./test.css": [[2, ".test{a: b}", ""]]
+	});
 	test("import camelcase", "@IMPORT url(test.css);\n.class { a: b c d; }", [
 		[2, ".test{a: b}", ""],
 		[1, ".class { a: b c d; }", ""]


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
Fixes #781

**Did you add tests for your changes?**
Yep

**If relevant, did you update the README?**
Nope 

**Summary**
This removes trailing whitespace from unquoted import urls

**Does this PR introduce a breaking change?**
It shouldn't