### PR TITLE
chore(package): switch from `lodash.camelcase` to `lodash` (`dependencies`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 npm-debug.log
+.idea

--- a/lib/compile-exports.js
+++ b/lib/compile-exports.js
@@ -1,4 +1,4 @@
-var camelCase = require("lodash.camelcase");
+var camelCase = require("lodash/camelCase");
 
 function dashesCamelCase(str) {
   return str.replace(/-+(\w)/g, function(match, firstLetter) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2141,10 +2141,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -2185,11 +2184,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.create": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "css-selector-tokenizer": "^0.7.0",
     "icss-utils": "^2.1.0",
     "loader-utils": "^1.0.2",
-    "lodash.camelcase": "^4.3.0",
+    "lodash": "^4.17.11",
     "postcss": "^6.0.23",
     "postcss-modules-extract-imports": "^1.2.0",
     "postcss-modules-local-by-default": "^1.2.0",


### PR DESCRIPTION
What:
update lodash to latest 4.17.11, switching away from deprecated lodash.xxx module

Why:
Remediate CVE-2018-3721 by upgrading lodash away from vulnerable and deprecated modules