### PR TITLE
Support deduplication of string module ids (optimization.namedModules)

### DIFF
--- a/lib/css-base.js
+++ b/lib/css-base.js
@@ -25,7 +25,7 @@ module.exports = function(useSourceMap) {
 		var alreadyImportedModules = {};
 		for(var i = 0; i < this.length; i++) {
 			var id = this[i][0];
-			if(typeof id === "number")
+			if(id != null)
 				alreadyImportedModules[id] = true;
 		}
 		for(i = 0; i < modules.length; i++) {
@@ -34,7 +34,7 @@ module.exports = function(useSourceMap) {
 			// this implementation is not 100% perfect for weird media query combinations
 			//  when a module is imported multiple times with different media queries.
 			//  I hope this will never occur (Hey this way we have smaller bundles)
-			if(typeof item[0] !== "number" || !alreadyImportedModules[item[0]]) {
+			if(item[0] == null || !alreadyImportedModules[item[0]]) {
 				if(mediaQuery && !item[2]) {
 					item[2] = mediaQuery;
 				} else if(mediaQuery) {

--- a/test/cssBaseTest.js
+++ b/test/cssBaseTest.js
@@ -52,6 +52,21 @@ describe("css-base", function() {
 			"@media print{body { d: 4; }}" +
 			"@media screen{body { a: 1; }}");
 	});
+	it("should import named modules", function() {
+		var m = base();
+		var m1 = ["./module1", "body { a: 1; }", "screen"];
+		var m2 = ["./module2", "body { b: 2; }", ""];
+		var m3 = ["./module3", "body { c: 3; }", ""];
+		var m4 = ["./module4", "body { d: 4; }", ""];
+		m.i([m2, m3], "");
+		m.i([m2], "");
+		m.i([m2, m4], "print");
+		m.push(m1);
+		m.toString().should.be.eql("body { b: 2; }" +
+			"body { c: 3; }" +
+			"@media print{body { d: 4; }}" +
+			"@media screen{body { a: 1; }}");
+	});
 	it("should toString with source mapping", function() {
 		var m = base(true);
 		m.push([1, "body { a: 1; }", "", {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
A bugfix

**Did you add tests for your changes?**
Yes, the contributed test fails without the change

**If relevant, did you update the README?**
Not required

**Summary**
Adds support for deduplication of string module ids, introduced with `optimization.namedModules` option in `webpack`. Fixes https://github.com/webpack-contrib/css-loader/issues/772

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No