### PR TITLE
refactor: drop getLocalIdent compatibility with webpack@2 and webpack@3

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,26 +91,17 @@ function compileExports(exports, camelCaseKeys, valueHandler) {
 
 function getLocalIdent(loaderContext, localIdentName, localName, options) {
   if (!options.context) {
-    if (loaderContext.rootContext) {
-      // eslint-disable-next-line no-param-reassign
-      options.context = loaderContext.rootContext;
-    } else if (
-      loaderContext.options &&
-      typeof loaderContext.options.context === 'string'
-    ) {
-      // eslint-disable-next-line no-param-reassign
-      options.context = loaderContext.options.context;
-    } else {
-      // eslint-disable-next-line no-param-reassign
-      options.context = loaderContext.context;
-    }
+    // eslint-disable-next-line no-param-reassign
+    options.context = loaderContext.rootContext;
   }
 
-  const request = path.relative(options.context, loaderContext.resourcePath);
+  const request = path
+    .relative(options.context, loaderContext.resourcePath)
+    .replace(/\\/g, '/');
 
   // eslint-disable-next-line no-param-reassign
-  options.content = `${options.hashPrefix +
-    request.replace(/\\/g, '/')}+${localName}`;
+  options.content = `${options.hashPrefix + request}+${localName}`;
+
   // eslint-disable-next-line no-param-reassign
   localIdentName = localIdentName.replace(/\[local\]/gi, localName);
 

--- a/test/__snapshots__/getLocalIdent-option.test.js.snap
+++ b/test/__snapshots__/getLocalIdent-option.test.js.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getLocalIdent option should accepts arguments: errors 1`] = `Array []`;
+
+exports[`getLocalIdent option should accepts arguments: locals 1`] = `
+Object {
+  "abc": "foo",
+  "def": "foo",
+  "ghi": "foo",
+  "jkl": "foo",
+}
+`;
+
+exports[`getLocalIdent option should accepts arguments: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ".foo .foo {
+  color: red;
+}
+
+.foo .foo {
+  color: blue;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`getLocalIdent option should accepts arguments: warnings 1`] = `Array []`;
+
+exports[`getLocalIdent option should respect \`context\` option: errors 1`] = `Array []`;
+
+exports[`getLocalIdent option should respect \`context\` option: locals 1`] = `
+Object {
+  "abc": "_1hksQTRR0UD9eKPUBlgn0X",
+  "def": "_3oo37UGTAgyDe0MeQom-28",
+  "ghi": "_2ZRWT_7WiIKpOei7U0eJzJ",
+  "jkl": "aQ1rQfhbWSRMXFXxIfQcx",
+}
+`;
+
+exports[`getLocalIdent option should respect \`context\` option: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._1hksQTRR0UD9eKPUBlgn0X ._3oo37UGTAgyDe0MeQom-28 {
+  color: red;
+}
+
+._2ZRWT_7WiIKpOei7U0eJzJ .aQ1rQfhbWSRMXFXxIfQcx {
+  color: blue;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`getLocalIdent option should respect \`context\` option: warnings 1`] = `Array []`;
+
 exports[`getLocalIdent option should work (\`modules: false\`): errors 1`] = `Array []`;
 
 exports[`getLocalIdent option should work (\`modules: false\`): locals 1`] = `

--- a/test/getLocalIdent-option.test.js
+++ b/test/getLocalIdent-option.test.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const { webpack, evaluated } = require('./helpers');
 
 describe('getLocalIdent option', () => {
@@ -32,6 +34,62 @@ describe('getLocalIdent option', () => {
           getLocalIdent() {
             return 'foo';
           },
+        },
+      },
+    };
+    const testId = './modules/getLocalIdent.css';
+    const stats = await webpack(testId, config);
+    const { modules } = stats.toJson();
+    const module = modules.find((m) => m.id === testId);
+    const evaluatedModule = evaluated(module.source);
+
+    expect(evaluatedModule).toMatchSnapshot('module (evaluated)');
+    expect(evaluatedModule.locals).toMatchSnapshot('locals');
+    expect(stats.compilation.warnings).toMatchSnapshot('warnings');
+    expect(stats.compilation.errors).toMatchSnapshot('errors');
+  });
+
+  it('should accepts arguments', async () => {
+    const config = {
+      loader: {
+        options: {
+          modules: true,
+          localIdentRegExp: 'regExp',
+          context: 'context',
+          hashPrefix: 'hash',
+          getLocalIdent(loaderContext, localIdentName, localName, options) {
+            expect(loaderContext).toBeDefined();
+            expect(typeof localIdentName).toBe('string');
+            expect(typeof localName).toBe('string');
+            expect(options).toBeDefined();
+
+            expect(options.regExp).toBe('regExp');
+            expect(options.context).toBe('context');
+            expect(options.hashPrefix).toBe('hash');
+
+            return 'foo';
+          },
+        },
+      },
+    };
+    const testId = './modules/getLocalIdent.css';
+    const stats = await webpack(testId, config);
+    const { modules } = stats.toJson();
+    const module = modules.find((m) => m.id === testId);
+    const evaluatedModule = evaluated(module.source);
+
+    expect(evaluatedModule).toMatchSnapshot('module (evaluated)');
+    expect(evaluatedModule.locals).toMatchSnapshot('locals');
+    expect(stats.compilation.warnings).toMatchSnapshot('warnings');
+    expect(stats.compilation.errors).toMatchSnapshot('errors');
+  });
+
+  it('should respect `context` option', async () => {
+    const config = {
+      loader: {
+        options: {
+          context: path.resolve(__dirname, 'fixtures/modules'),
+          modules: true,
         },
       },
     };


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Drop compatibility `getLocalIdent` option with `webpack@2` and `webpack@3`

### Breaking Changes

In theory - yes, but loader require `webpack@4` and it does not make sense so no

### Additional Info

no