### PR TITLE
feat: allow to disable css modules and disable their by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ It's useful when you, for instance, need to post process the CSS as a string.
 |:--:|:--:|:-----:|:----------|
 |**[`url`](#url)**|`{Boolean}`|`true`| Enable/Disable `url()` handling|
 |**[`import`](#import)** |`{Boolean}`|`true`| Enable/Disable @import handling|
-|**[`modules`](#modules)**|`{Boolean}`|`false`|Enable/Disable CSS Modules|
+|**[`modules`](#modules)**|`{Boolean\|String}`|`false`|Enable/Disable CSS Modules and setup mode|
 |**[`localIdentName`](#localidentname)**|`{String}`|`[hash:base64]`|Configure the generated ident|
 |**[`sourceMap`](#sourcemap)**|`{Boolean}`|`false`|Enable/Disable Sourcemaps|
 |**[`camelCase`](#camelcase)**|`{Boolean\|String}`|`false`|Export Classnames in CamelCase|
@@ -129,17 +129,33 @@ To import styles from a node module path, prefix it with a `~`:
 
 ### [`modules`](https://github.com/css-modules/css-modules)
 
-The query parameter `modules` enables the **CSS Modules** spec.
+The `modules` option enables/disables the **CSS Modules** spec and setup basic behaviour.
 
-This enables local scoped CSS by default. (You can switch it off with `:global(...)` or `:global` for selectors and/or rules.).
+|Name|Type|Description|
+|:--:|:--:|:----------|
+|**`true`**|`{Boolean}`|Enables local scoped CSS by default (use **local** mode by default)|
+|**`false`**|`{Boolean}`|Disable the **CSS Modules** spec, all **CSS Modules** features (like `@value`, `:local`, `:global` and `composes`) will not work|
+|**`'local'`** |`{String}`|Enables local scoped CSS by default (same as `true` value)|
+|**`'global'`**|`{String}`|Enables global scoped CSS by default|
 
-#### `Scope`
+Using `false` value increase performance because we avoid parsing **CSS Modules** features, it will be useful for developers who use vanilla css or use other technologies.
 
-By default CSS exports all classnames into a global selector scope. Styles can be locally scoped to avoid globally scoping styles.
+You can read about **modes** below
+
+##### `Scope`
+ 
+Using `local` value requires you to specify `:global` classes.
+Using `global` value requires you to specify `:local` classes.
+
+You can find more information [here](https://github.com/css-modules/css-modules).
+ 
+Styles can be locally scoped to avoid globally scoping styles.
 
 The syntax `:local(.className)` can be used to declare `className` in the local scope. The local identifiers are exported by the module.
 
-With `:local` (without brackets) local mode can be switched on for this selector. `:global(.className)` can be used to declare an explicit global selector. With `:global` (without brackets) global mode can be switched on for this selector.
+With `:local` (without brackets) local mode can be switched on for this selector. 
+The `:global(.className)` nocation can be used to declare an explicit global selector. 
+With `:global` (without brackets) global mode can be switched on for this selector.
 
 The loader replaces local selectors with unique identifiers. The chosen unique identifiers are exported by the module.
 
@@ -177,7 +193,7 @@ file.png => ./file.png
 
 You can use `:local(#someId)`, but this is not recommended. Use classes instead of ids.
 
-#### `Composing`
+##### `Composing`
 
 When declaring a local classname you can compose a local class from another local classname.
 
@@ -213,7 +229,7 @@ exports.locals = {
 }
 ```
 
-#### `Importing`
+##### `Importing`
 
 To import a local classname from another module.
 
@@ -282,7 +298,7 @@ You can also specify the absolute path to your custom `getLocalIdent` function t
 
 To include source maps set the `sourceMap` option.
 
-I.e. the extract-text-webpack-plugin can handle them.
+I.e. the `mini-css-extract-plugin` can handle them.
 
 They are not enabled by default because they expose a runtime overhead and increase in bundle size (JS source maps do not). In addition to that relative paths are buggy and you need to use an absolute public path which includes the server URL.
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -62,43 +62,55 @@ module.exports = function loader(content, map, meta) {
 
   const resolveImport = options.import !== false;
   const resolveUrl = options.url !== false;
-  const loaderContext = this;
 
-  const plugins = [
-    modulesValues,
-    localByDefault({
-      mode: options.modules ? 'local' : 'global',
-      rewriteUrl(global, url) {
-        if (resolveUrl) {
-          // eslint-disable-next-line no-param-reassign
-          url = url.trim();
+  const plugins = [];
 
-          if (!url.replace(/\s/g, '').length || !isUrlRequest(url)) {
-            return url;
+  if (options.modules) {
+    const loaderContext = this;
+    const mode =
+      typeof options.modules === 'boolean' ? 'local' : options.modules;
+
+    plugins.push(
+      modulesValues,
+      localByDefault({
+        mode,
+        rewriteUrl(global, url) {
+          if (resolveUrl) {
+            // eslint-disable-next-line no-param-reassign
+            url = url.trim();
+
+            if (!url.replace(/\s/g, '').length || !isUrlRequest(url)) {
+              return url;
+            }
+
+            if (global) {
+              return urlToRequest(url);
+            }
           }
 
-          if (global) {
-            return urlToRequest(url);
-          }
-        }
+          return url;
+        },
+      }),
+      extractImports(),
+      modulesScope({
+        generateScopedName: function generateScopedName(exportName) {
+          const localIdentName = options.localIdentName || '[hash:base64]';
+          const customGetLocalIdent = options.getLocalIdent || getLocalIdent;
 
-        return url;
-      },
-    }),
-    extractImports(),
-    modulesScope({
-      generateScopedName: function generateScopedName(exportName) {
-        const localIdentName = options.localIdentName || '[hash:base64]';
-        const customGetLocalIdent = options.getLocalIdent || getLocalIdent;
-
-        return customGetLocalIdent(loaderContext, localIdentName, exportName, {
-          regExp: options.localIdentRegExp,
-          hashPrefix: options.hashPrefix || '',
-          context: options.context,
-        });
-      },
-    }),
-  ];
+          return customGetLocalIdent(
+            loaderContext,
+            localIdentName,
+            exportName,
+            {
+              regExp: options.localIdentRegExp,
+              hashPrefix: options.hashPrefix || '',
+              context: options.context,
+            }
+          );
+        },
+      })
+    );
+  }
 
   if (resolveImport) {
     plugins.push(importParser());

--- a/test/__snapshots__/import-option.test.js.snap
+++ b/test/__snapshots__/import-option.test.js.snap
@@ -1,8 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`import option false and modules false: errors 1`] = `Array []`;
+exports[`import option false and modules \`false\`: errors 1`] = `Array []`;
 
-exports[`import option false and modules false: module (evaluated) 1`] = `
+exports[`import option false and modules \`false\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@import url(test-other.css) (min-width: 100px);
+
+@value def from './values.css';
+@value other from './values.css';
+@value other from './values.css';
+@value something from './something.css';
+@value foo: blue;
+@value bar: block;
+
+.ghi {
+  color: def;
+}
+
+.class {
+  color: foo;
+}
+
+.other {
+  display: bar;
+}
+
+.other-other {
+  width: something;
+}
+
+.green {
+  color: other;
+}
+
+.foo {
+  prop: def;
+  duplicate: other;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`import option false and modules \`false\`: module 1`] = `
+"exports = module.exports = require(\\"../../../lib/runtime/api.js\\")(false);
+// imports
+
+
+// module
+exports.push([module.id, \\"@import url(test-other.css) (min-width: 100px);\\\\n\\\\n@value def from './values.css';\\\\n@value other from './values.css';\\\\n@value other from './values.css';\\\\n@value something from './something.css';\\\\n@value foo: blue;\\\\n@value bar: block;\\\\n\\\\n.ghi {\\\\n  color: def;\\\\n}\\\\n\\\\n.class {\\\\n  color: foo;\\\\n}\\\\n\\\\n.other {\\\\n  display: bar;\\\\n}\\\\n\\\\n.other-other {\\\\n  width: something;\\\\n}\\\\n\\\\n.green {\\\\n  color: other;\\\\n}\\\\n\\\\n.foo {\\\\n  prop: def;\\\\n  duplicate: other;\\\\n}\\\\n\\", \\"\\"]);
+
+// exports
+"
+`;
+
+exports[`import option false and modules \`false\`: warnings 1`] = `Array []`;
+
+exports[`import option false and modules \`global\`: errors 1`] = `Array []`;
+
+exports[`import option false and modules \`global\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -50,7 +109,7 @@ Array [
 ]
 `;
 
-exports[`import option false and modules false: module 1`] = `
+exports[`import option false and modules \`global\`: module 1`] = `
 "exports = module.exports = require(\\"../../../lib/runtime/api.js\\")(false);
 // imports
 exports.i(require(\\"-!../../../index.js??ref--4-0!./values.css\\"), \\"\\");
@@ -69,11 +128,11 @@ exports.locals = {
 };"
 `;
 
-exports[`import option false and modules false: warnings 1`] = `Array []`;
+exports[`import option false and modules \`global\`: warnings 1`] = `Array []`;
 
-exports[`import option false and modules true: errors 1`] = `Array []`;
+exports[`import option false and modules \`local\`: errors 1`] = `Array []`;
 
-exports[`import option false and modules true: module (evaluated) 1`] = `
+exports[`import option false and modules \`local\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -121,7 +180,7 @@ Array [
 ]
 `;
 
-exports[`import option false and modules true: module 1`] = `
+exports[`import option false and modules \`local\`: module 1`] = `
 "exports = module.exports = require(\\"../../../lib/runtime/api.js\\")(false);
 // imports
 exports.i(require(\\"-!../../../index.js??ref--4-0!./values.css\\"), \\"\\");
@@ -144,7 +203,82 @@ exports.locals = {
 };"
 `;
 
-exports[`import option false and modules true: warnings 1`] = `Array []`;
+exports[`import option false and modules \`local\`: warnings 1`] = `Array []`;
+
+exports[`import option false and modules \`true\`: errors 1`] = `Array []`;
+
+exports[`import option false and modules \`true\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "
+",
+    "",
+  ],
+  Array [
+    3,
+    "
+",
+    "",
+  ],
+  Array [
+    1,
+    "@import url(test-other.css) (min-width: 100px);
+
+._3r49KZIIAltPknAjdNVZ-7 {
+  color: red;
+}
+
+._4o0o5eKzoeDOSI0_cR8mr {
+  color: blue;
+}
+
+._2wLXKM9pRjt1oRYvf0Wo3Q {
+  display: block;
+}
+
+._1RBgqC8j3f4iU6k-ocmIG7 {
+  width: 2112moon;
+}
+
+._1lCIckG6C8tRZjGNDsAPWr {
+  color: green;
+}
+
+._1YL4f0i_603GTMRC_pnsP5 {
+  prop: red;
+  duplicate: green;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`import option false and modules \`true\`: module 1`] = `
+"exports = module.exports = require(\\"../../../lib/runtime/api.js\\")(false);
+// imports
+exports.i(require(\\"-!../../../index.js??ref--4-0!./values.css\\"), \\"\\");
+exports.i(require(\\"-!../../../index.js??ref--4-0!./something.css\\"), \\"\\");
+
+// module
+exports.push([module.id, \\"@import url(test-other.css) (min-width: 100px);\\\\n\\\\n._3r49KZIIAltPknAjdNVZ-7 {\\\\n  color: \\" + require(\\"-!../../../index.js??ref--4-0!./values.css\\").locals[\\"def\\"] + \\";\\\\n}\\\\n\\\\n._4o0o5eKzoeDOSI0_cR8mr {\\\\n  color: blue;\\\\n}\\\\n\\\\n._2wLXKM9pRjt1oRYvf0Wo3Q {\\\\n  display: block;\\\\n}\\\\n\\\\n._1RBgqC8j3f4iU6k-ocmIG7 {\\\\n  width: \\" + require(\\"-!../../../index.js??ref--4-0!./something.css\\").locals[\\"something\\"] + \\";\\\\n}\\\\n\\\\n._1lCIckG6C8tRZjGNDsAPWr {\\\\n  color: \\" + require(\\"-!../../../index.js??ref--4-0!./values.css\\").locals[\\"other\\"] + \\";\\\\n}\\\\n\\\\n._1YL4f0i_603GTMRC_pnsP5 {\\\\n  prop: \\" + require(\\"-!../../../index.js??ref--4-0!./values.css\\").locals[\\"def\\"] + \\";\\\\n  duplicate: \\" + require(\\"-!../../../index.js??ref--4-0!./values.css\\").locals[\\"other\\"] + \\";\\\\n}\\\\n\\", \\"\\"]);
+
+// exports
+exports.locals = {
+	\\"def\\": \\"\\" + require(\\"-!../../../index.js??ref--4-0!./values.css\\").locals[\\"def\\"] + \\"\\",
+	\\"other\\": \\"_2wLXKM9pRjt1oRYvf0Wo3Q\\",
+	\\"something\\": \\"\\" + require(\\"-!../../../index.js??ref--4-0!./something.css\\").locals[\\"something\\"] + \\"\\",
+	\\"foo\\": \\"_1YL4f0i_603GTMRC_pnsP5\\",
+	\\"bar\\": \\"block\\",
+	\\"ghi\\": \\"_3r49KZIIAltPknAjdNVZ-7\\",
+	\\"class\\": \\"_4o0o5eKzoeDOSI0_cR8mr\\",
+	\\"other-other\\": \\"_1RBgqC8j3f4iU6k-ocmIG7\\",
+	\\"green\\": \\"_1lCIckG6C8tRZjGNDsAPWr\\"
+};"
+`;
+
+exports[`import option false and modules \`true\`: warnings 1`] = `Array []`;
 
 exports[`import option false: errors 1`] = `Array []`;
 

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -485,19 +485,19 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 main.hero, .hero.main {
-  background-image: img1x.png;
+  background-image: url(/webpack/public/path/img1x.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
 main.hero, .hero.main {
-  background-image: img2x.png;
+  background-image:  url(/webpack/public/path/img2x.png);
 }
 }
 
 main.hero, .hero.main {
   background-image: -webkit-image-set(url(/webpack/public/path/img1x.png) 1x, url(/webpack/public/path/img2x.png) 2x);
-  background-image: image-set(\\"img1x.png\\" 1x, \\"img2x.png\\" 2x);
+  background-image: image-set(url(/webpack/public/path/img1x.png) 1x, url(/webpack/public/path/img2x.png) 2x);
 }
 
 a {
@@ -520,7 +520,7 @@ exports = module.exports = require(\\"../../../lib/runtime/api.js\\")(false);
 
 
 // module
-exports.push([module.id, \\":root {\\\\n  --fontSize: 1rem;\\\\n  --mainColor: rgba(18,52,86,0.47059);\\\\n  --secondaryColor: rgba(102, 51, 153, 0.9);\\\\n}\\\\n\\\\nhtml {\\\\n  overflow-x: hidden;\\\\n  overflow-y: auto;\\\\n  overflow: hidden auto;\\\\n}\\\\n\\\\n@media (max-width: 50rem) {\\\\n  body {\\\\n    color: rgba(18,52,86,0.47059);\\\\n    color: var(--mainColor);\\\\n    font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;\\\\n    font-size: 1rem;\\\\n    font-size: var(--fontSize);\\\\n    line-height: calc(1rem * 1.5);\\\\n    line-height: calc(var(--fontSize) * 1.5);\\\\n    word-wrap: break-word;\\\\n    padding-left: calc(1rem / 2 + 1px);\\\\n    padding-right: calc(1rem / 2 + 1px);\\\\n    padding-left: calc(var(--fontSize) / 2 + 1px);\\\\n    padding-right: calc(var(--fontSize) / 2 + 1px);\\\\n  }\\\\n}\\\\n\\\\nh1,h2,h3,h4,h5,h6 {\\\\n  margin-top: 0;\\\\n  margin-bottom: 0;\\\\n}\\\\n\\\\nmain.hero, .hero.main {\\\\n  background-image: img1x.png;\\\\n}\\\\n\\\\n@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {\\\\n\\\\nmain.hero, .hero.main {\\\\n  background-image: img2x.png;\\\\n}\\\\n}\\\\n\\\\nmain.hero, .hero.main {\\\\n  background-image: -webkit-image-set(url(\\" + escape(require(\\"./img1x.png\\")) + \\") 1x, url(\\" + escape(require(\\"./img2x.png\\")) + \\") 2x);\\\\n  background-image: image-set(\\\\\\"img1x.png\\\\\\" 1x, \\\\\\"img2x.png\\\\\\" 2x);\\\\n}\\\\n\\\\na {\\\\n  color: rgba(0, 0, 255, 0.9)\\\\n}\\\\n\\\\na:hover {\\\\n    color: #639;\\\\n  }\\\\n\\", \\"\\"]);
+exports.push([module.id, \\":root {\\\\n  --fontSize: 1rem;\\\\n  --mainColor: rgba(18,52,86,0.47059);\\\\n  --secondaryColor: rgba(102, 51, 153, 0.9);\\\\n}\\\\n\\\\nhtml {\\\\n  overflow-x: hidden;\\\\n  overflow-y: auto;\\\\n  overflow: hidden auto;\\\\n}\\\\n\\\\n@media (max-width: 50rem) {\\\\n  body {\\\\n    color: rgba(18,52,86,0.47059);\\\\n    color: var(--mainColor);\\\\n    font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;\\\\n    font-size: 1rem;\\\\n    font-size: var(--fontSize);\\\\n    line-height: calc(1rem * 1.5);\\\\n    line-height: calc(var(--fontSize) * 1.5);\\\\n    word-wrap: break-word;\\\\n    padding-left: calc(1rem / 2 + 1px);\\\\n    padding-right: calc(1rem / 2 + 1px);\\\\n    padding-left: calc(var(--fontSize) / 2 + 1px);\\\\n    padding-right: calc(var(--fontSize) / 2 + 1px);\\\\n  }\\\\n}\\\\n\\\\nh1,h2,h3,h4,h5,h6 {\\\\n  margin-top: 0;\\\\n  margin-bottom: 0;\\\\n}\\\\n\\\\nmain.hero, .hero.main {\\\\n  background-image: url(\\" + escape(require(\\"./img1x.png\\")) + \\");\\\\n}\\\\n\\\\n@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {\\\\n\\\\nmain.hero, .hero.main {\\\\n  background-image:  url(\\" + escape(require(\\"./img2x.png\\")) + \\");\\\\n}\\\\n}\\\\n\\\\nmain.hero, .hero.main {\\\\n  background-image: -webkit-image-set(url(\\" + escape(require(\\"./img1x.png\\")) + \\") 1x, url(\\" + escape(require(\\"./img2x.png\\")) + \\") 2x);\\\\n  background-image: image-set(url(\\" + escape(require(\\"./img1x.png\\")) + \\") 1x, url(\\" + escape(require(\\"./img2x.png\\")) + \\") 2x);\\\\n}\\\\n\\\\na {\\\\n  color: rgba(0, 0, 255, 0.9)\\\\n}\\\\n\\\\na:hover {\\\\n    color: #639;\\\\n  }\\\\n\\", \\"\\"]);
 
 // exports
 "

--- a/test/__snapshots__/localIdentName-option.test.js.snap
+++ b/test/__snapshots__/localIdentName-option.test.js.snap
@@ -2,46 +2,37 @@
 
 exports[`localIdentName option basic: errors 1`] = `Array []`;
 
-exports[`localIdentName option basic: locals 1`] = `
-Object {
-  "-a0-34a___f": "_2nJ5XVdGAwkzTI324zw6Pg",
-  "_test": "_23te_4QsMe8I6hzxjH0MUx",
-  "className": "_1E8Hx67EIx_tltp58vyNJ0",
-  "someId": "_3w7JetWWlr8Zm4sxZ-ANzU",
-  "subClass": "_3lo0JvMLLK_gjw1mbsomb3",
-  "test": "NW9YAb4ijHq-3lCxF5vFu",
-}
-`;
+exports[`localIdentName option basic: locals 1`] = `undefined`;
 
 exports[`localIdentName option basic: module (evaluated) 1`] = `
 Array [
   Array [
     1,
-    ".NW9YAb4ijHq-3lCxF5vFu {
+    ":local(.test) {
   background: red;
 }
 
-._23te_4QsMe8I6hzxjH0MUx {
+:local(._test) {
   background: blue;
 }
 
-._1E8Hx67EIx_tltp58vyNJ0 {
+:local(.className) {
   background: red;
 }
 
-#_3w7JetWWlr8Zm4sxZ-ANzU {
+:local(#someId) {
   background: green;
 }
 
-._1E8Hx67EIx_tltp58vyNJ0 ._3lo0JvMLLK_gjw1mbsomb3 {
+:local(.className .subClass) {
   color: green;
 }
 
-#_3w7JetWWlr8Zm4sxZ-ANzU ._3lo0JvMLLK_gjw1mbsomb3 {
+:local(#someId .subClass) {
   color: blue;
 }
 
-._2nJ5XVdGAwkzTI324zw6Pg {
+:local(.-a0-34a___f) {
   color: red;
 }
 ",
@@ -54,46 +45,37 @@ exports[`localIdentName option basic: warnings 1`] = `Array []`;
 
 exports[`localIdentName option should have hash: errors 1`] = `Array []`;
 
-exports[`localIdentName option should have hash: locals 1`] = `
-Object {
-  "-a0-34a___f": "localIdentName---a0-34a___f--3RHUZ",
-  "_test": "localIdentName--_test--3Q--B",
-  "className": "localIdentName--className--3wBIH",
-  "someId": "localIdentName--someId--mxosG",
-  "subClass": "localIdentName--subClass--3jIM-",
-  "test": "localIdentName--test--1Os7J",
-}
-`;
+exports[`localIdentName option should have hash: locals 1`] = `undefined`;
 
 exports[`localIdentName option should have hash: module (evaluated) 1`] = `
 Array [
   Array [
     1,
-    ".localIdentName--test--1Os7J {
+    ":local(.test) {
   background: red;
 }
 
-.localIdentName--_test--3Q--B {
+:local(._test) {
   background: blue;
 }
 
-.localIdentName--className--3wBIH {
+:local(.className) {
   background: red;
 }
 
-#localIdentName--someId--mxosG {
+:local(#someId) {
   background: green;
 }
 
-.localIdentName--className--3wBIH .localIdentName--subClass--3jIM- {
+:local(.className .subClass) {
   color: green;
 }
 
-#localIdentName--someId--mxosG .localIdentName--subClass--3jIM- {
+:local(#someId .subClass) {
   color: blue;
 }
 
-.localIdentName---a0-34a___f--3RHUZ {
+:local(.-a0-34a___f) {
   color: red;
 }
 ",
@@ -106,46 +88,37 @@ exports[`localIdentName option should have hash: warnings 1`] = `Array []`;
 
 exports[`localIdentName option should have path naming with context: errors 1`] = `Array []`;
 
-exports[`localIdentName option should have path naming with context: locals 1`] = `
-Object {
-  "-a0-34a___f": "fixtures-modules--localIdentName---a0-34a___f",
-  "_test": "fixtures-modules--localIdentName--_test",
-  "className": "fixtures-modules--localIdentName--className",
-  "someId": "fixtures-modules--localIdentName--someId",
-  "subClass": "fixtures-modules--localIdentName--subClass",
-  "test": "fixtures-modules--localIdentName--test",
-}
-`;
+exports[`localIdentName option should have path naming with context: locals 1`] = `undefined`;
 
 exports[`localIdentName option should have path naming with context: module (evaluated) 1`] = `
 Array [
   Array [
     1,
-    ".fixtures-modules--localIdentName--test {
+    ":local(.test) {
   background: red;
 }
 
-.fixtures-modules--localIdentName--_test {
+:local(._test) {
   background: blue;
 }
 
-.fixtures-modules--localIdentName--className {
+:local(.className) {
   background: red;
 }
 
-#fixtures-modules--localIdentName--someId {
+:local(#someId) {
   background: green;
 }
 
-.fixtures-modules--localIdentName--className .fixtures-modules--localIdentName--subClass {
+:local(.className .subClass) {
   color: green;
 }
 
-#fixtures-modules--localIdentName--someId .fixtures-modules--localIdentName--subClass {
+:local(#someId .subClass) {
   color: blue;
 }
 
-.fixtures-modules--localIdentName---a0-34a___f {
+:local(.-a0-34a___f) {
   color: red;
 }
 ",
@@ -158,46 +131,37 @@ exports[`localIdentName option should have path naming with context: warnings 1`
 
 exports[`localIdentName option should prefixes leading hyphen + digit with underscore: errors 1`] = `Array []`;
 
-exports[`localIdentName option should prefixes leading hyphen + digit with underscore: locals 1`] = `
-Object {
-  "-a0-34a___f": "_-1-a0-34a___f",
-  "_test": "_-1_test",
-  "className": "_-1className",
-  "someId": "_-1someId",
-  "subClass": "_-1subClass",
-  "test": "_-1test",
-}
-`;
+exports[`localIdentName option should prefixes leading hyphen + digit with underscore: locals 1`] = `undefined`;
 
 exports[`localIdentName option should prefixes leading hyphen + digit with underscore: module (evaluated) 1`] = `
 Array [
   Array [
     1,
-    "._-1test {
+    ":local(.test) {
   background: red;
 }
 
-._-1_test {
+:local(._test) {
   background: blue;
 }
 
-._-1className {
+:local(.className) {
   background: red;
 }
 
-#_-1someId {
+:local(#someId) {
   background: green;
 }
 
-._-1className ._-1subClass {
+:local(.className .subClass) {
   color: green;
 }
 
-#_-1someId ._-1subClass {
+:local(#someId .subClass) {
   color: blue;
 }
 
-._-1-a0-34a___f {
+:local(.-a0-34a___f) {
   color: red;
 }
 ",
@@ -210,46 +174,37 @@ exports[`localIdentName option should prefixes leading hyphen + digit with under
 
 exports[`localIdentName option should prefixes two leading hyphens with underscore: errors 1`] = `Array []`;
 
-exports[`localIdentName option should prefixes two leading hyphens with underscore: locals 1`] = `
-Object {
-  "-a0-34a___f": "_---a0-34a___f",
-  "_test": "_--_test",
-  "className": "_--className",
-  "someId": "_--someId",
-  "subClass": "_--subClass",
-  "test": "_--test",
-}
-`;
+exports[`localIdentName option should prefixes two leading hyphens with underscore: locals 1`] = `undefined`;
 
 exports[`localIdentName option should prefixes two leading hyphens with underscore: module (evaluated) 1`] = `
 Array [
   Array [
     1,
-    "._--test {
+    ":local(.test) {
   background: red;
 }
 
-._--_test {
+:local(._test) {
   background: blue;
 }
 
-._--className {
+:local(.className) {
   background: red;
 }
 
-#_--someId {
+:local(#someId) {
   background: green;
 }
 
-._--className ._--subClass {
+:local(.className .subClass) {
   color: green;
 }
 
-#_--someId ._--subClass {
+:local(#someId .subClass) {
   color: blue;
 }
 
-._---a0-34a___f {
+:local(.-a0-34a___f) {
   color: red;
 }
 ",
@@ -262,46 +217,37 @@ exports[`localIdentName option should prefixes two leading hyphens with undersco
 
 exports[`localIdentName option should saves underscore prefix in exported class names: errors 1`] = `Array []`;
 
-exports[`localIdentName option should saves underscore prefix in exported class names: locals 1`] = `
-Object {
-  "-a0-34a___f": "-a0-34a___f",
-  "_test": "_test",
-  "className": "className",
-  "someId": "someId",
-  "subClass": "subClass",
-  "test": "test",
-}
-`;
+exports[`localIdentName option should saves underscore prefix in exported class names: locals 1`] = `undefined`;
 
 exports[`localIdentName option should saves underscore prefix in exported class names: module (evaluated) 1`] = `
 Array [
   Array [
     1,
-    ".test {
+    ":local(.test) {
   background: red;
 }
 
-._test {
+:local(._test) {
   background: blue;
 }
 
-.className {
+:local(.className) {
   background: red;
 }
 
-#someId {
+:local(#someId) {
   background: green;
 }
 
-.className .subClass {
+:local(.className .subClass) {
   color: green;
 }
 
-#someId .subClass {
+:local(#someId .subClass) {
   color: blue;
 }
 
-.-a0-34a___f {
+:local(.-a0-34a___f) {
   color: red;
 }
 ",
@@ -314,46 +260,37 @@ exports[`localIdentName option should saves underscore prefix in exported class 
 
 exports[`localIdentName option should use hash prefix: errors 1`] = `Array []`;
 
-exports[`localIdentName option should use hash prefix: locals 1`] = `
-Object {
-  "-a0-34a___f": "-a0-34a___f--e99d667fe0ceff9363b011302ac3f508",
-  "_test": "_test--d745495d407559ef605c9072243801fd",
-  "className": "className--eab624d1bc6b9c6b6a4278d1030dd690",
-  "someId": "someId--a0ce220cc9bbb1ee0e85cc0d1f0c6aa9",
-  "subClass": "subClass--2c82998be8a2b2e94ad7be56c9e685cd",
-  "test": "test--307c32aa793aaec9aecded85a9fdd448",
-}
-`;
+exports[`localIdentName option should use hash prefix: locals 1`] = `undefined`;
 
 exports[`localIdentName option should use hash prefix: module (evaluated) 1`] = `
 Array [
   Array [
     1,
-    ".test--307c32aa793aaec9aecded85a9fdd448 {
+    ":local(.test) {
   background: red;
 }
 
-._test--d745495d407559ef605c9072243801fd {
+:local(._test) {
   background: blue;
 }
 
-.className--eab624d1bc6b9c6b6a4278d1030dd690 {
+:local(.className) {
   background: red;
 }
 
-#someId--a0ce220cc9bbb1ee0e85cc0d1f0c6aa9 {
+:local(#someId) {
   background: green;
 }
 
-.className--eab624d1bc6b9c6b6a4278d1030dd690 .subClass--2c82998be8a2b2e94ad7be56c9e685cd {
+:local(.className .subClass) {
   color: green;
 }
 
-#someId--a0ce220cc9bbb1ee0e85cc0d1f0c6aa9 .subClass--2c82998be8a2b2e94ad7be56c9e685cd {
+:local(#someId .subClass) {
   color: blue;
 }
 
-.-a0-34a___f--e99d667fe0ceff9363b011302ac3f508 {
+:local(.-a0-34a___f) {
   color: red;
 }
 ",

--- a/test/__snapshots__/modules-option.test.js.snap
+++ b/test/__snapshots__/modules-option.test.js.snap
@@ -19,6 +19,50 @@ Array [
 
 exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
 
+exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ".class-1, .class-10 .bar-1 {
+	color: green;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "bar-1": "_bar-1",
+  "class-1": "_class-1",
+  "class-10": "_class-10",
+}
+`;
+
+exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._class-1, ._class-10 ._bar-1 {
+	color: green;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
+
 exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
 exports[`modules case \`class-names\`: (export \`all\`) (\`modules\` value is \`true)\`: locals 1`] = `
@@ -52,6 +96,28 @@ exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` val
 
 exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
 
+exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "bar-1": "_bar-1",
+  "class-1": "_class-1",
+  "class-10": "_class-10",
+}
+`;
+
+exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
+
 exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
 exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` value is \`true)\`: locals 1`] = `undefined`;
@@ -68,14 +134,31 @@ exports[`modules case \`class-names\`: (export \`only locals\`) (\`modules\` val
 
 exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ":local(.c1/*.c2*/.c3) { background: red; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "c1": "_c1",
   "c3": "_c3",
 }
 `;
 
-exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -86,7 +169,29 @@ Array [
 ]
 `;
 
-exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "c1": "_c1",
+  "c3": "_c3",
+}
+`;
+
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._c1/*.c2*/._c3 { background: red; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`comment-in-local\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -114,14 +219,35 @@ exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\
 
 exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "c1": "_c1",
   "c3": "_c3",
 }
 `;
 
-exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "c1": "_c1",
+  "c3": "_c3",
+}
+`;
+
+exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`comment-in-local\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -163,6 +289,64 @@ Array [
 
 exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
 
+exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "/*
+ * a ' above
+ */
+
+.bg {
+  background-image: url(/webpack/public/path/img.png);
+}
+
+/*
+ * a ' below
+ */
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "bg": "_bg",
+}
+`;
+
+exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "/*
+ * a ' above
+ */
+
+._bg {
+  background-image: url(/webpack/public/path/img.png);
+}
+
+/*
+ * a ' below
+ */
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
+
 exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
 exports[`modules case \`comments\`: (export \`all\`) (\`modules\` value is \`true)\`: locals 1`] = `
@@ -202,6 +386,26 @@ exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
 
+exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "bg": "_bg",
+}
+`;
+
+exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
+
 exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
 exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value is \`true)\`: locals 1`] = `undefined`;
@@ -216,14 +420,32 @@ exports[`modules case \`comments\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ":local(.c1) { a: 1; }
+:local(.c2) { composes: c1; b: 1; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "c1": "_c1",
   "c2": "_c2 _c1",
 }
 `;
 
-exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -235,7 +457,30 @@ Array [
 ]
 `;
 
-exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "c1": "_c1",
+  "c2": "_c2 _c1",
+}
+`;
+
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._c1 { a: 1; }
+._c2 { b: 1; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -264,14 +509,35 @@ exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "c1": "_c1",
   "c2": "_c2 _c1",
 }
 `;
 
-exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "c1": "_c1",
+  "c2": "_c2 _c1",
+}
+`;
+
+exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -288,7 +554,26 @@ exports[`modules case \`composes\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ":local(.c1) { composes: c2 from \\"./file.css\\"; b: 1; }
+:local(.c3) { composes: c1; b: 3; }
+:local(.c5) { composes: c2 c4 from \\"./file.css\\"; b: 5; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "c1": "_c1 _c2",
   "c3": "_c3 _c1 _c2",
@@ -296,7 +581,7 @@ Object {
 }
 `;
 
-exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -325,7 +610,48 @@ Array [
 ]
 `;
 
-exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "c1": "_c1 _c2",
+  "c3": "_c3 _c1 _c2",
+  "c5": "_c5 _c2 _c4",
+}
+`;
+
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "._c2 {
+  color: red;
+}
+
+._c4 {
+  color: blue;
+}
+
+._test{
+  c: d
+}
+",
+    "",
+  ],
+  Array [
+    1,
+    "._c1 { b: 1; }
+._c3 { b: 3; }
+._c5 { b: 5; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes-1\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -372,7 +698,15 @@ exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` valu
 
 exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "c1": "_c1 _c2",
   "c3": "_c3 _c1 _c2",
@@ -380,7 +714,21 @@ Object {
 }
 `;
 
-exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "c1": "_c1 _c2",
+  "c3": "_c3 _c1 _c2",
+  "c5": "_c5 _c2 _c4",
+}
+`;
+
+exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -398,7 +746,26 @@ exports[`modules case \`composes-1\`: (export \`only locals\`) (\`modules\` valu
 
 exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ":local(.c1) { composes: c-2 from \\"./file.css\\"; b: 1; }
+:local(.c3) { composes: c1; b: 3; }
+:local(.c5) { composes: c-2 c4 from \\"./file.css\\"; b: 5; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "c1": "_c1 _c-2",
   "c3": "_c3 _c1 _c-2",
@@ -406,7 +773,7 @@ Object {
 }
 `;
 
-exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -435,7 +802,48 @@ Array [
 ]
 `;
 
-exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "c1": "_c1 _c-2",
+  "c3": "_c3 _c1 _c-2",
+  "c5": "_c5 _c-2 _c4",
+}
+`;
+
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "._c-2 {
+  color: red;
+}
+
+._c4 {
+  color: blue;
+}
+
+._test{
+  c: d
+}
+",
+    "",
+  ],
+  Array [
+    1,
+    "._c1 { b: 1; }
+._c3 { b: 3; }
+._c5 { b: 5; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes-2\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -482,7 +890,15 @@ exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` valu
 
 exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "c1": "_c1 _c-2",
   "c3": "_c3 _c1 _c-2",
@@ -490,7 +906,21 @@ Object {
 }
 `;
 
-exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "c1": "_c1 _c-2",
+  "c3": "_c3 _c1 _c-2",
+  "c5": "_c5 _c-2 _c4",
+}
+`;
+
+exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -508,13 +938,33 @@ exports[`modules case \`composes-2\`: (export \`only locals\`) (\`modules\` valu
 
 exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ":local(.abc) {
+  composes: def1 from \\"./file1.css\\";
+  composes: def2 from \\"./file2.css\\";
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "abc": "_abc _def1 _def2",
 }
 `;
 
-exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -542,7 +992,45 @@ Array [
 ]
 `;
 
-exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "abc": "_abc _def1 _def2",
+}
+`;
+
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "._def1 {
+  color: red;
+}
+",
+    "",
+  ],
+  Array [
+    3,
+    "._def2 {
+  color: blue;
+}
+",
+    "",
+  ],
+  Array [
+    1,
+    "._abc {
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes-multiple\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -586,13 +1074,33 @@ exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules
 
 exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "abc": "_abc _def1 _def2",
 }
 `;
 
-exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "abc": "_abc _def1 _def2",
+}
+`;
+
+exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -608,13 +1116,32 @@ exports[`modules case \`composes-multiple\`: (export \`only locals\`) (\`modules
 
 exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ":local(.abc) {
+  composes: def from \\"./file.css\\";
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "abc": "_abc _def",
 }
 `;
 
-exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -634,7 +1161,37 @@ Array [
 ]
 `;
 
-exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "abc": "_abc _def",
+}
+`;
+
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "._def {
+  color: red;
+}
+",
+    "",
+  ],
+  Array [
+    1,
+    "._abc {
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes-with-importing\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -670,13 +1227,33 @@ exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`m
 
 exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "abc": "_abc _def",
 }
 `;
 
-exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "abc": "_abc _def",
+}
+`;
+
+exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -692,13 +1269,34 @@ exports[`modules case \`composes-with-importing\`: (export \`only locals\`) (\`m
 
 exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value blue: red;
+
+.a {
+  border: 1px solid blue;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "blue": "red",
 }
 `;
 
-exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -711,7 +1309,31 @@ Array [
 ]
 `;
 
-exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "a": "_a",
+  "blue": "red",
+}
+`;
+
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._a {
+  border: 1px solid red;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`declaration-value\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -741,13 +1363,34 @@ exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules
 
 exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "blue": "red",
 }
 `;
 
-exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "a": "_a",
+  "blue": "red",
+}
+`;
+
+exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`declaration-value\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -825,6 +1468,143 @@ Array [
 `;
 
 exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ".a {
+	color: green;
+}
+
+@keyframes bounce {
+	0% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+	5% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+}
+
+@-webkit-keyframes bounce2 {
+	0% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+	5% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+}
+
+.bounce {
+	animation-name: bounce;
+	animation: bounce2 1s ease;
+}
+
+.bounce2 {
+	color: green;
+	animation: bounce 1s ease;
+	animation-name: bounce2;
+}
+
+.bounce3 {
+	animation: bounce 1s ease, bounce2
+}
+
+.bounce4 {
+	animation: bounce 1s ease, bounce2;
+}
+
+.b {
+	color: green;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "a": "_a",
+  "b": "_b",
+  "bounce": "_bounce",
+  "bounce2": "_bounce2",
+  "bounce3": "_bounce3",
+  "bounce4": "_bounce4",
+}
+`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._a {
+	color: green;
+}
+
+@keyframes _bounce {
+	0% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+	5% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+}
+
+@-webkit-keyframes _bounce2 {
+	0% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+	5% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+}
+
+._bounce {
+	animation-name: _bounce;
+	animation: _bounce2 1s ease;
+}
+
+._bounce2 {
+	color: green;
+	animation: _bounce 1s ease;
+	animation-name: _bounce2;
+}
+
+._bounce3 {
+	animation: _bounce 1s ease, _bounce2
+}
+
+._bounce4 {
+	animation: _bounce 1s ease, _bounce2;
+}
+
+._b {
+	color: green;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`keyframes-and-animation\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -907,6 +1687,31 @@ exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`m
 
 exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
 
+exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "a": "_a",
+  "b": "_b",
+  "bounce": "_bounce",
+  "bounce2": "_bounce2",
+  "bounce3": "_bounce3",
+  "bounce4": "_bounce4",
+}
+`;
+
+exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
+
 exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
 exports[`modules case \`keyframes-and-animation\`: (export \`only locals\`) (\`modules\` value is \`true)\`: locals 1`] = `undefined`;
@@ -929,6 +1734,59 @@ exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`f
 exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
 exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ".a {
+	color: green;
+	animation: a;
+}
+
+@keyframes b {
+	0% { left: 10px; }
+	100% { left: 20px; }
+}
+
+.b {
+	animation: b;
+}
+
+@keyframes :global(c) {
+	0% { left: 10px; }
+	100% { left: 20px; }
+}
+
+.c {
+	animation: c1;
+	animation: c2, c3, c4;
+}
+
+@keyframes :global(d) {
+	0% { left: 10px; }
+	100% { left: 20px; }
+}
+
+:global .d1 {
+	animation: d1;
+	animation: d2, d3, d4;
+}
+
+:global(.d2) {
+	animation: d2;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -975,7 +1833,71 @@ Array [
 ]
 `;
 
-exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "a": "_a",
+  "b": "_b",
+  "c": "_c",
+  "c1": "_c1",
+  "c2": "_c2",
+  "c3": "_c3",
+  "c4": "_c4",
+  "d2": "_d2",
+}
+`;
+
+exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._a {
+	color: green;
+	animation: _a;
+}
+
+@keyframes _b {
+	0% { left: 10px; }
+	100% { left: 20px; }
+}
+
+._b {
+	animation: _b;
+}
+
+@keyframes c {
+	0% { left: 10px; }
+	100% { left: 20px; }
+}
+
+._c {
+	animation: _c1;
+	animation: _c2, _c3, _c4;
+}
+
+@keyframes d {
+	0% { left: 10px; }
+	100% { left: 20px; }
+}
+
+.d1 {
+	animation: d1;
+	animation: d2, d3, d4;
+}
+
+.d2 {
+	animation: _d2;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`leak-scope\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1049,6 +1971,33 @@ exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` valu
 
 exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
 
+exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "a": "_a",
+  "b": "_b",
+  "c": "_c",
+  "c1": "_c1",
+  "c2": "_c2",
+  "c3": "_c3",
+  "c4": "_c4",
+  "d2": "_d2",
+}
+`;
+
+exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
+
 exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
 exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` value is \`true)\`: locals 1`] = `undefined`;
@@ -1070,7 +2019,30 @@ exports[`modules case \`leak-scope\`: (export \`only locals\`) (\`modules\` valu
 
 exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ".abc :local(.def) {
+  color: red;
+}
+
+:local .ghi .jkl {
+  color: blue;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "def": "_def",
   "ghi": "_ghi",
@@ -1078,7 +2050,7 @@ Object {
 }
 `;
 
-exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -1095,7 +2067,37 @@ Array [
 ]
 `;
 
-exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "abc": "_abc",
+  "def": "_def",
+  "ghi": "_ghi",
+  "jkl": "_jkl",
+}
+`;
+
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._abc ._def {
+  color: red;
+}
+
+._ghi ._jkl {
+  color: blue;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`local\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1131,7 +2133,15 @@ exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is 
 
 exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "def": "_def",
   "ghi": "_ghi",
@@ -1139,7 +2149,22 @@ Object {
 }
 `;
 
-exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "abc": "_abc",
+  "def": "_def",
+  "ghi": "_ghi",
+  "jkl": "_jkl",
+}
+`;
+
+exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1158,7 +2183,27 @@ exports[`modules case \`local\`: (export \`only locals\`) (\`modules\` value is 
 
 exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ":local(.className) { background: red; }
+:local(#someId) { background: green; }
+:local(.className .subClass) { color: green; }
+:local(#someId .subClass) { color: blue; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "className": "_className",
   "someId": "_someId",
@@ -1166,7 +2211,7 @@ Object {
 }
 `;
 
-exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -1180,7 +2225,33 @@ Array [
 ]
 `;
 
-exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "className": "_className",
+  "someId": "_someId",
+  "subClass": "_subClass",
+}
+`;
+
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._className { background: red; }
+#_someId { background: green; }
+._className ._subClass { color: green; }
+#_someId ._subClass { color: blue; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`local-2\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1212,7 +2283,15 @@ exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value i
 
 exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "className": "_className",
   "someId": "_someId",
@@ -1220,7 +2299,21 @@ Object {
 }
 `;
 
-exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "className": "_className",
+  "someId": "_someId",
+  "subClass": "_subClass",
+}
+`;
+
+exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1238,14 +2331,37 @@ exports[`modules case \`local-2\`: (export \`only locals\`) (\`modules\` value i
 
 exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ":local(.abc) {
+  color: red;
+}
+:local(.def) {
+  composes: abc;
+  background: green;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "abc": "_abc",
   "def": "_def _abc",
 }
 `;
 
-exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -1261,7 +2377,34 @@ Array [
 ]
 `;
 
-exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "abc": "_abc",
+  "def": "_def _abc",
+}
+`;
+
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._abc {
+  color: red;
+}
+._def {
+  background: green;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`local-and-composes\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1294,14 +2437,35 @@ exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`module
 
 exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "abc": "_abc",
   "def": "_def _abc",
 }
 `;
 
-exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "abc": "_abc",
+  "def": "_def _abc",
+}
+`;
+
+exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1318,7 +2482,26 @@ exports[`modules case \`local-and-composes\`: (export \`only locals\`) (\`module
 
 exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ":local(.c1[data-attr=\\".c2)]'\\"]:not(.c3):not(.c4)) {
+  background: red;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "c1": "_c1",
   "c3": "_c3",
@@ -1326,7 +2509,7 @@ Object {
 }
 `;
 
-exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -1339,7 +2522,32 @@ Array [
 ]
 `;
 
-exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "c1": "_c1",
+  "c3": "_c3",
+  "c4": "_c4",
+}
+`;
+
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._c1[data-attr=\\".c2)]'\\"]:not(._c3):not(._c4) {
+  background: red;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`local-with-string\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1370,7 +2578,15 @@ exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules
 
 exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "c1": "_c1",
   "c3": "_c3",
@@ -1378,7 +2594,21 @@ Object {
 }
 `;
 
-exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "c1": "_c1",
+  "c3": "_c3",
+  "c4": "_c4",
+}
+`;
+
+exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1396,13 +2626,36 @@ exports[`modules case \`local-with-string\`: (export \`only locals\`) (\`modules
 
 exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value small: (max-width: 599px);
+
+@media small {
+  .header {
+    box-shadow: 0 0 4px #1F4F7F;
+  }
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "small": "(max-width: 599px)",
 }
 `;
 
-exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -1417,7 +2670,33 @@ Array [
 ]
 `;
 
-exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "header": "_header",
+  "small": "(max-width: 599px)",
+}
+`;
+
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@media (max-width: 599px) {
+  ._header {
+    box-shadow: 0 0 4px #1F4F7F;
+  }
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`media\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1449,13 +2728,34 @@ exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is 
 
 exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "small": "(max-width: 599px)",
 }
 `;
 
-exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "header": "_header",
+  "small": "(max-width: 599px)",
+}
+`;
+
+exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1472,13 +2772,35 @@ exports[`modules case \`media\`: (export \`only locals\`) (\`modules\` value is 
 
 exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value small from './file.css';
+@media small {
+  .header {
+    box-shadow: 0 0 4px #1F4F7F;
+  }
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "small": "(max-width: 599px)",
 }
 `;
 
-exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -1499,7 +2821,39 @@ Array [
 ]
 `;
 
-exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "header": "_header",
+  "small": "(max-width: 599px)",
+}
+`;
+
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "
+",
+    "",
+  ],
+  Array [
+    1,
+    "@media (max-width: 599px) {
+  ._header {
+    box-shadow: 0 0 4px #1F4F7F;
+  }
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`media-2\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1537,13 +2891,34 @@ exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value i
 
 exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "small": "(max-width: 599px)",
 }
 `;
 
-exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "header": "_header",
+  "small": "(max-width: 599px)",
+}
+`;
+
+exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1560,7 +2935,25 @@ exports[`modules case \`media-2\`: (export \`only locals\`) (\`modules\` value i
 
 exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ".c1 :local .c2 .c3 :global .c4 :local .c5, .c6 :local .c7 { background: red; }
+.c8 { background: red; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "c2": "_c2",
   "c3": "_c3",
@@ -1569,7 +2962,7 @@ Object {
 }
 `;
 
-exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -1581,7 +2974,35 @@ Array [
 ]
 `;
 
-exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "c1": "_c1",
+  "c2": "_c2",
+  "c3": "_c3",
+  "c5": "_c5",
+  "c6": "_c6",
+  "c7": "_c7",
+  "c8": "_c8",
+}
+`;
+
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._c1 ._c2 ._c3 .c4 ._c5, ._c6 ._c7 { background: red; }
+._c8 { background: red; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`mode-switching\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1615,7 +3036,15 @@ exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` 
 
 exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "c2": "_c2",
   "c3": "_c3",
@@ -1624,7 +3053,25 @@ Object {
 }
 `;
 
-exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "c1": "_c1",
+  "c2": "_c2",
+  "c3": "_c3",
+  "c5": "_c5",
+  "c6": "_c6",
+  "c7": "_c7",
+  "c8": "_c8",
+}
+`;
+
+exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`mode-switching\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1671,6 +3118,71 @@ a[href=\\"#b.c\\"].x.y {
 
 exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
 
+exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ".a .b, .c .d, #id {
+	color: green;
+	font-size: 1.5pt;
+}
+a[href=\\"#b.c\\"].x.y {
+	color: green;
+	font-size: 1.5pt;
+}
+@keyframes z {
+  2.5% {color: green;}
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "a": "_a",
+  "b": "_b",
+  "c": "_c",
+  "d": "_d",
+  "id": "_id",
+  "x": "_x",
+  "y": "_y",
+  "z": "_z",
+}
+`;
+
+exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._a ._b, ._c ._d, #_id {
+	color: green;
+	font-size: 1.5pt;
+}
+a[href=\\"#b.c\\"]._x._y {
+	color: green;
+	font-size: 1.5pt;
+}
+@keyframes _z {
+  2.5% {color: green;}
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
+
 exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
 exports[`modules case \`simple\`: (export \`all\`) (\`modules\` value is \`true)\`: locals 1`] = `
@@ -1716,6 +3228,33 @@ exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is
 exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
 
 exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "a": "_a",
+  "b": "_b",
+  "c": "_c",
+  "d": "_d",
+  "id": "_id",
+  "x": "_x",
+  "y": "_y",
+  "z": "_z",
+}
+`;
+
+exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`simple\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1766,6 +3305,70 @@ Array [
 
 exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
 
+exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    ".a {
+	background: url(/webpack/public/path/img.png);
+	background: url(/webpack/public/path/img.png);
+	background: url(\\"/webpack/public/path/img img.png\\");
+	background: url(\\"/webpack/public/path/img img.png\\");
+	background: url(/webpack/public/path/img.png);
+	background: url(/webpack/public/path/img.png#?iefix);
+	background: url(\\"#hash\\");
+	background: url(\\"#\\");
+	background: url(data:image/png;base64,AAA);
+	background: url(http://example.com/image.jpg);
+	background: url(//example.com/image.png);
+	background: green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) url(/webpack/public/path/img.png) url(\\"/webpack/public/path/img img.png\\") xyz;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "a": "_a",
+}
+`;
+
+exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._a {
+	background: url(/webpack/public/path/img.png);
+	background: url(/webpack/public/path/img.png);
+	background: url(\\"/webpack/public/path/img img.png\\");
+	background: url(\\"/webpack/public/path/img img.png\\");
+	background: url(/webpack/public/path/img.png);
+	background: url(/webpack/public/path/img.png#?iefix);
+	background: url(\\"#hash\\");
+	background: url(\\"#\\");
+	background: url(data:image/png;base64,AAA);
+	background: url(http://example.com/image.jpg);
+	background: url(//example.com/image.png);
+	background: green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) url(/webpack/public/path/img.png) url(\\"/webpack/public/path/img img.png\\") xyz;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
+
 exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
 exports[`modules case \`urls\`: (export \`all\`) (\`modules\` value is \`true)\`: locals 1`] = `
@@ -1808,6 +3411,26 @@ exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \
 
 exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
 
+exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "a": "_a",
+}
+`;
+
+exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
+
 exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
 exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \`true)\`: locals 1`] = `undefined`;
@@ -1822,7 +3445,32 @@ exports[`modules case \`urls\`: (export \`only locals\`) (\`modules\` value is \
 
 exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value aaa: red;
+@value bbb: green;
+@value ccc: aaa;
+
+.a {
+	background: aaa;
+	background: bbb;
+	background: ccc;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "aaa": "red",
   "bbb": "green",
@@ -1830,7 +3478,7 @@ Object {
 }
 `;
 
-exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -1845,7 +3493,35 @@ Array [
 ]
 `;
 
-exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "a": "_a",
+  "aaa": "red",
+  "bbb": "green",
+  "ccc": "red",
+}
+`;
+
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._a {
+	background: red;
+	background: green;
+	background: red;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1879,7 +3555,15 @@ exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is
 
 exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "aaa": "red",
   "bbb": "green",
@@ -1887,7 +3571,22 @@ Object {
 }
 `;
 
-exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "a": "_a",
+  "aaa": "red",
+  "bbb": "green",
+  "ccc": "red",
+}
+`;
+
+exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1906,14 +3605,32 @@ exports[`modules case \`values\`: (export \`only locals\`) (\`modules\` value is
 
 exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value def: red;
+@value ghi: 1px solid black;
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "def": "red",
   "ghi": "1px solid black",
 }
 `;
 
-exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -1924,7 +3641,29 @@ Array [
 ]
 `;
 
-exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "def": "red",
+  "ghi": "1px solid black",
+}
+`;
+
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-1\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1952,14 +3691,35 @@ exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "def": "red",
   "ghi": "1px solid black",
 }
 `;
 
-exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "def": "red",
+  "ghi": "1px solid black",
+}
+`;
+
+exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -1976,13 +3736,31 @@ exports[`modules case \`values-1\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value def: red;
+.ghi { color: def; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "def": "red",
 }
 `;
 
-exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -1993,7 +3771,29 @@ Array [
 ]
 `;
 
-exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "def": "red",
+  "ghi": "_ghi",
+}
+`;
+
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._ghi { color: red; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-2\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2021,13 +3821,34 @@ exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "def": "red",
 }
 `;
 
-exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "def": "red",
+  "ghi": "_ghi",
+}
+`;
+
+exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2044,13 +3865,31 @@ exports[`modules case \`values-2\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value def from './file.css';
+.ghi { color: def; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "def": "red",
 }
 `;
 
-exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -2067,7 +3906,35 @@ Array [
 ]
 `;
 
-exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "def": "red",
+  "ghi": "_ghi",
+}
+`;
+
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "
+",
+    "",
+  ],
+  Array [
+    1,
+    "._ghi { color: red; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-3\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2101,13 +3968,34 @@ exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "def": "red",
 }
 `;
 
-exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "def": "red",
+  "ghi": "_ghi",
+}
+`;
+
+exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2124,14 +4012,33 @@ exports[`modules case \`values-3\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value def as aaa from './file1.css';
+@value def as bbb from './file2.css';
+.ghi { background: aaa, bbb, def; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "aaa": "red",
   "bbb": "green",
 }
 `;
 
-exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -2154,7 +4061,42 @@ Array [
 ]
 `;
 
-exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "aaa": "red",
+  "bbb": "green",
+  "ghi": "_ghi",
+}
+`;
+
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "
+",
+    "",
+  ],
+  Array [
+    3,
+    "
+",
+    "",
+  ],
+  Array [
+    1,
+    "._ghi { background: red, green, def; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-4\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2195,14 +4137,36 @@ exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "aaa": "red",
   "bbb": "green",
 }
 `;
 
-exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "aaa": "red",
+  "bbb": "green",
+  "ghi": "_ghi",
+}
+`;
+
+exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2220,14 +4184,33 @@ exports[`modules case \`values-4\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value color from './file1.css';
+@value shadow: 0 0 color,0 0 color;
+.ghi { box-shadow: shadow; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "color": "red",
   "shadow": "0 0 red,0 0 red",
 }
 `;
 
-exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -2244,7 +4227,36 @@ Array [
 ]
 `;
 
-exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "color": "red",
+  "ghi": "_ghi",
+  "shadow": "0 0 red,0 0 red",
+}
+`;
+
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "
+",
+    "",
+  ],
+  Array [
+    1,
+    "._ghi { box-shadow: 0 0 red,0 0 red; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-5\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2279,14 +4291,36 @@ exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "color": "red",
   "shadow": "0 0 red,0 0 red",
 }
 `;
 
-exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "color": "red",
+  "ghi": "_ghi",
+  "shadow": "0 0 red,0 0 red",
+}
+`;
+
+exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2304,14 +4338,33 @@ exports[`modules case \`values-5\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value color from './file1.css';
+@value shadow: 0 0 color ,0 0 color;
+.ghi { box-shadow: shadow; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "color": "red",
   "shadow": "0 0 red ,0 0 red",
 }
 `;
 
-exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -2328,7 +4381,36 @@ Array [
 ]
 `;
 
-exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "color": "red",
+  "ghi": "_ghi",
+  "shadow": "0 0 red ,0 0 red",
+}
+`;
+
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "
+",
+    "",
+  ],
+  Array [
+    1,
+    "._ghi { box-shadow: 0 0 red ,0 0 red; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-6\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2363,14 +4445,36 @@ exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "color": "red",
   "shadow": "0 0 red ,0 0 red",
 }
 `;
 
-exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "color": "red",
+  "ghi": "_ghi",
+  "shadow": "0 0 red ,0 0 red",
+}
+`;
+
+exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2388,14 +4492,33 @@ exports[`modules case \`values-6\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value color from './file1.css';
+@value shadow: 0 0 color, 0 0 color;
+.ghi { box-shadow: shadow; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "color": "red",
   "shadow": "0 0 red, 0 0 red",
 }
 `;
 
-exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     2,
@@ -2412,7 +4535,36 @@ Array [
 ]
 `;
 
-exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "color": "red",
+  "ghi": "_ghi",
+  "shadow": "0 0 red, 0 0 red",
+}
+`;
+
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    2,
+    "
+",
+    "",
+  ],
+  Array [
+    1,
+    "._ghi { box-shadow: 0 0 red, 0 0 red; }
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-7\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2447,14 +4599,36 @@ exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "color": "red",
   "shadow": "0 0 red, 0 0 red",
 }
 `;
 
-exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "color": "red",
+  "ghi": "_ghi",
+  "shadow": "0 0 red, 0 0 red",
+}
+`;
+
+exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2472,13 +4646,35 @@ exports[`modules case \`values-7\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value shadow-color: rgba(0, 0, 0, 0.5);
+
+.shadow {
+  box-shadow: 0 10px 10px shadow-color,
+    10px 0px 5px shadow-color;
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "shadow-color": "rgba(0, 0, 0, 0.5)",
 }
 `;
 
-exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -2492,7 +4688,32 @@ Array [
 ]
 `;
 
-exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "shadow": "_shadow",
+  "shadow-color": "rgba(0, 0, 0, 0.5)",
+}
+`;
+
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._shadow {
+  box-shadow: 0 10px 10px rgba(0, 0, 0, 0.5),
+    10px 0px 5px rgba(0, 0, 0, 0.5);
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-8\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2523,13 +4744,34 @@ exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "shadow-color": "rgba(0, 0, 0, 0.5)",
 }
 `;
 
-exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "shadow": "_shadow",
+  "shadow-color": "rgba(0, 0, 0, 0.5)",
+}
+`;
+
+exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2546,13 +4788,58 @@ exports[`modules case \`values-8\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`false)\`: errors 1`] = `Array []`;
 
-exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "@value def: red;
+
+.foo1 {
+  prop: func(def);
+}
+
+.foo2 {
+  prop: func(10px def);
+}
+
+.foo3 {
+  prop: func(def 10px);
+}
+
+.foo4 {
+  prop: func(10px def 10px);
+}
+
+.foo5 {
+  prop: func(10px, def);
+}
+
+.foo6 {
+  prop: func(def, 10px);
+}
+
+.foo7 {
+  prop: func(10px, def, 10px);
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`global)\`: locals 1`] = `
 Object {
   "def": "red",
 }
 `;
 
-exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Array [
   Array [
     1,
@@ -2589,7 +4876,61 @@ Array [
 ]
 `;
 
-exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`local)\`: locals 1`] = `
+Object {
+  "def": "red",
+  "foo1": "_foo1",
+  "foo2": "_foo2",
+  "foo3": "_foo3",
+  "foo4": "_foo4",
+  "foo5": "_foo5",
+  "foo6": "_foo6",
+  "foo7": "_foo7",
+}
+`;
+
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Array [
+  Array [
+    1,
+    "._foo1 {
+  prop: func(red);
+}
+
+._foo2 {
+  prop: func(10px red);
+}
+
+._foo3 {
+  prop: func(red 10px);
+}
+
+._foo4 {
+  prop: func(10px red 10px);
+}
+
+._foo5 {
+  prop: func(10px, red);
+}
+
+._foo6 {
+  prop: func(red, 10px);
+}
+
+._foo7 {
+  prop: func(10px, red, 10px);
+}
+",
+    "",
+  ],
+]
+`;
+
+exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-9\`: (export \`all\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 
@@ -2649,13 +4990,40 @@ exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value 
 
 exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`false)\`: locals 1`] = `undefined`;
 
-exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`false)\`: module (evaluated) 1`] = `Object {}`;
+
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`global)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`global)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`global)\`: module (evaluated) 1`] = `
 Object {
   "def": "red",
 }
 `;
 
-exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`false)\`: warnings 1`] = `Array []`;
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`global)\`: warnings 1`] = `Array []`;
+
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`local)\`: errors 1`] = `Array []`;
+
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`local)\`: locals 1`] = `undefined`;
+
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`local)\`: module (evaluated) 1`] = `
+Object {
+  "def": "red",
+  "foo1": "_foo1",
+  "foo2": "_foo2",
+  "foo3": "_foo3",
+  "foo4": "_foo4",
+  "foo5": "_foo5",
+  "foo6": "_foo6",
+  "foo7": "_foo7",
+}
+`;
+
+exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`local)\`: warnings 1`] = `Array []`;
 
 exports[`modules case \`values-9\`: (export \`only locals\`) (\`modules\` value is \`true)\`: errors 1`] = `Array []`;
 

--- a/test/__snapshots__/url-option.test.js.snap
+++ b/test/__snapshots__/url-option.test.js.snap
@@ -15,49 +15,49 @@ Array [
   Array [
     1,
     ".class {
-  background: url('img.png');
+  background: url('./img.png');
 }
 
 .class {
-  background: url(\\"img.png\\");
+  background: url(\\"./img.png\\");
 }
 
 .class {
-  background: url(img.png);
+  background: url(./img.png);
 }
 
 .class {
-  background: url(\\"img.png#hash\\");
+  background: url(\\"./img.png#hash\\");
 }
 
 .class {
   background: url(
-    \\"img.png\\"
+    \\"./img.png\\"
   );
 }
 
 .class {
-  background: green url( 'img.png' ) xyz;
+  background: green url( './img.png' ) xyz;
 }
 
 .class {
-  background: green url( \\"img.png\\" ) xyz;
+  background: green url( \\"./img.png\\" ) xyz;
 }
 
 .class {
-  background: green url( img.png ) xyz;
+  background: green url( ./img.png ) xyz;
 }
 
 .class {
-  background: green url(~package/img.png) url(other-img.png) xyz;
+  background: green /* url(~package/img.png) */ url(./other-img.png) xyz;
 }
 
 .class {
-  background: green url( \\"img img.png\\" ) xyz;
+  background: green url( \\"./img img.png\\" ) xyz;
 }
 
 .class {
-  background: green url( 'img img.png' ) xyz;
+  background: green url( './img img.png' ) xyz;
 }
 
 .class {
@@ -93,20 +93,20 @@ Array [
 }
 
 @font-face {
-  src: url(font.woff) format('woff'),
-    url('font.woff2') format('woff2'),
-    url(\\"font.eot\\") format('eot'),
-    url(~package/font.ttf) format('truetype'),
-    url(\\"font with spaces.eot\\") format(\\"embedded-opentype\\"),
-    url('font.svg#svgFontName') format('svg'),
-    url('font.woff2?foo=bar') format('woff2'),
-    url(\\"font.eot?#iefix\\") format('embedded-opentype'),
-    url(\\"font with spaces.eot?#iefix\\") format('embedded-opentype');
+  src: url(./font.woff) format('woff'),
+    url('./font.woff2') format('woff2'),
+    url(\\"./font.eot\\") format('eot'),
+    /*url(~package/font.ttf) format('truetype'), */
+    url(\\"./font with spaces.eot\\") format(\\"embedded-opentype\\"),
+    url('./font.svg#svgFontName') format('svg'),
+    url('./font.woff2?foo=bar') format('woff2'),
+    url(\\"./font.eot?#iefix\\") format('embedded-opentype'),
+    url(\\"./font with spaces.eot?#iefix\\") format('embedded-opentype');
 }
 
 @media (min-width: 500px) {
   body {
-    background: url(\\"img.png\\");
+    background: url(\\"./img.png\\");
   }
 }
 
@@ -119,15 +119,15 @@ b {
 }
 
 @keyframes anim {
-  background: green url('img.png') xyz;
+  background: green url('./img.png') xyz;
 }
 
 .a {
-  background-image: -webkit-image-set(url('img1x.png') 1x, url('img2x.png') 2x)
+  background-image: -webkit-image-set(url('./img1x.png') 1x, url('./img2x.png') 2x)
 }
 
 .a {
-  background-image: image-set(url('img1x.png') 1x, url('img2x.png') 2x)
+  background-image: image-set(url('./img1x.png') 1x, url('./img2x.png') 2x)
 }
 
 .class {
@@ -161,27 +161,27 @@ b {
 }
 
 .class {
-  background: url(\\"img.png?foo\\");
+  background: url(\\"./img.png?foo\\");
 }
 
 .class {
-  background: url(\\"img.png?foo=bar\\");
+  background: url(\\"./img.png?foo=bar\\");
 }
 
 .class {
-  background: url(\\"img.png?foo=bar#hash\\");
+  background: url(\\"./img.png?foo=bar#hash\\");
 }
 
 .class {
-  background: url(\\"img.png?foo=bar#hash\\");
+  background: url(\\"./img.png?foo=bar#hash\\");
 }
 
 .class {
-  background: url(\\"img.png?\\");
+  background: url(\\"./img.png?\\");
 }
 
 .class {
-  background-image: url('img.png') url(\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\") url('img.png');
+  background-image: url('./img.png') url(\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\") url('./img.png');
 }
 
 .class {
@@ -204,7 +204,7 @@ exports[`url option false: module 1`] = `
 exports.i(require(\\"-!../../../index.js??ref--4-0!./imported.css\\"), \\"\\");
 
 // module
-exports.push([module.id, \\".class {\\\\n  background: url('img.png');\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"img.png\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(img.png);\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"img.png#hash\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\n    \\\\\\"img.png\\\\\\"\\\\n  );\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( 'img.png' ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( \\\\\\"img.png\\\\\\" ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( img.png ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(~package/img.png) url(other-img.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( \\\\\\"img img.png\\\\\\" ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( 'img img.png' ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(/img.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\\\\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\\\\\"data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2042%2026%27%20fill%3D%27%2523007aff%27%3E%3Crect%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%271%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2711%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2712%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2722%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2723%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3C%2Fsvg%3E\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  filter: url('data:image/svg+xml;charset=utf-8,<svg xmlns=\\\\\\"http://www.w3.org/2000/svg\\\\\\"><filter id=\\\\\\"filter\\\\\\"><feGaussianBlur in=\\\\\\"SourceAlpha\\\\\\" stdDeviation=\\\\\\"0\\\\\\" /><feOffset dx=\\\\\\"1\\\\\\" dy=\\\\\\"2\\\\\\" result=\\\\\\"offsetblur\\\\\\" /><feFlood flood-color=\\\\\\"rgba(255,255,255,1)\\\\\\" /><feComposite in2=\\\\\\"offsetblur\\\\\\" operator=\\\\\\"in\\\\\\" /><feMerge><feMergeNode /><feMergeNode in=\\\\\\"SourceGraphic\\\\\\" /></feMerge></filter></svg>#filter');\\\\n}\\\\n\\\\n.class {\\\\n  filter: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%5C%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%5C%22%3E%3Cfilter%20id%3D%5C%22filter%5C%22%3E%3CfeGaussianBlur%20in%3D%5C%22SourceAlpha%5C%22%20stdDeviation%3D%5C%220%5C%22%20%2F%3E%3CfeOffset%20dx%3D%5C%221%5C%22%20dy%3D%5C%222%5C%22%20result%3D%5C%22offsetblur%5C%22%20%2F%3E%3CfeFlood%20flood-color%3D%5C%22rgba(255%2C255%2C255%2C1)%5C%22%20%2F%3E%3CfeComposite%20in2%3D%5C%22offsetblur%5C%22%20operator%3D%5C%22in%5C%22%20%2F%3E%3CfeMerge%3E%3CfeMergeNode%20%2F%3E%3CfeMergeNode%20in%3D%5C%22SourceGraphic%5C%22%20%2F%3E%3C%2FfeMerge%3E%3C%2Ffilter%3E%3C%2Fsvg%3E%23filter');\\\\n}\\\\n\\\\n.highlight {\\\\n  filter: url(#highlight);\\\\n}\\\\n\\\\n.highlight {\\\\n  filter: url('#line-marker');\\\\n}\\\\n\\\\n@font-face {\\\\n  src: url(font.woff) format('woff'),\\\\n    url('font.woff2') format('woff2'),\\\\n    url(\\\\\\"font.eot\\\\\\") format('eot'),\\\\n    url(~package/font.ttf) format('truetype'),\\\\n    url(\\\\\\"font with spaces.eot\\\\\\") format(\\\\\\"embedded-opentype\\\\\\"),\\\\n    url('font.svg#svgFontName') format('svg'),\\\\n    url('font.woff2?foo=bar') format('woff2'),\\\\n    url(\\\\\\"font.eot?#iefix\\\\\\") format('embedded-opentype'),\\\\n    url(\\\\\\"font with spaces.eot?#iefix\\\\\\") format('embedded-opentype');\\\\n}\\\\n\\\\n@media (min-width: 500px) {\\\\n  body {\\\\n    background: url(\\\\\\"img.png\\\\\\");\\\\n  }\\\\n}\\\\n\\\\na {\\\\n  content: \\\\\\"do not use url(path)\\\\\\";\\\\n}\\\\n\\\\nb {\\\\n  content: 'do not \\\\\\"use\\\\\\" url(path)';\\\\n}\\\\n\\\\n@keyframes anim {\\\\n  background: green url('img.png') xyz;\\\\n}\\\\n\\\\n.a {\\\\n  background-image: -webkit-image-set(url('img1x.png') 1x, url('img2x.png') 2x)\\\\n}\\\\n\\\\n.a {\\\\n  background-image: image-set(url('img1x.png') 1x, url('img2x.png') 2x)\\\\n}\\\\n\\\\n.class {\\\\n  background: green url() xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url('') xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\\\\\"\\\\\\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url('   ') xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\\\n  \\\\n  ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(https://raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"img.png?foo\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"img.png?foo=bar\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"img.png?foo=bar#hash\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"img.png?foo=bar#hash\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"img.png?\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url('img.png') url(\\\\\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\\\\\") url('img.png');\\\\n}\\\\n\\\\n.class {\\\\n  background: ___CSS_LOADER_URL___;\\\\n  background: ___CSS_LOADER_URL___INDEX___;\\\\n  background: ___CSS_LOADER_URL___99999___;\\\\n  background: ___CSS_LOADER_IMPORT___;\\\\n  background: ___CSS_LOADER_IMPORT___INDEX___;\\\\n  background: ___CSS_LOADER_IMPORT___99999___;\\\\n}\\\\n\\", \\"\\"]);
+exports.push([module.id, \\".class {\\\\n  background: url('./img.png');\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"./img.png\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(./img.png);\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"./img.png#hash\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\n    \\\\\\"./img.png\\\\\\"\\\\n  );\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( './img.png' ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( \\\\\\"./img.png\\\\\\" ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( ./img.png ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green /* url(~package/img.png) */ url(./other-img.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( \\\\\\"./img img.png\\\\\\" ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url( './img img.png' ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(/img.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\\\\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\\\\\"data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2042%2026%27%20fill%3D%27%2523007aff%27%3E%3Crect%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%271%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2711%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2712%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2722%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2723%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3C%2Fsvg%3E\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  filter: url('data:image/svg+xml;charset=utf-8,<svg xmlns=\\\\\\"http://www.w3.org/2000/svg\\\\\\"><filter id=\\\\\\"filter\\\\\\"><feGaussianBlur in=\\\\\\"SourceAlpha\\\\\\" stdDeviation=\\\\\\"0\\\\\\" /><feOffset dx=\\\\\\"1\\\\\\" dy=\\\\\\"2\\\\\\" result=\\\\\\"offsetblur\\\\\\" /><feFlood flood-color=\\\\\\"rgba(255,255,255,1)\\\\\\" /><feComposite in2=\\\\\\"offsetblur\\\\\\" operator=\\\\\\"in\\\\\\" /><feMerge><feMergeNode /><feMergeNode in=\\\\\\"SourceGraphic\\\\\\" /></feMerge></filter></svg>#filter');\\\\n}\\\\n\\\\n.class {\\\\n  filter: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%5C%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%5C%22%3E%3Cfilter%20id%3D%5C%22filter%5C%22%3E%3CfeGaussianBlur%20in%3D%5C%22SourceAlpha%5C%22%20stdDeviation%3D%5C%220%5C%22%20%2F%3E%3CfeOffset%20dx%3D%5C%221%5C%22%20dy%3D%5C%222%5C%22%20result%3D%5C%22offsetblur%5C%22%20%2F%3E%3CfeFlood%20flood-color%3D%5C%22rgba(255%2C255%2C255%2C1)%5C%22%20%2F%3E%3CfeComposite%20in2%3D%5C%22offsetblur%5C%22%20operator%3D%5C%22in%5C%22%20%2F%3E%3CfeMerge%3E%3CfeMergeNode%20%2F%3E%3CfeMergeNode%20in%3D%5C%22SourceGraphic%5C%22%20%2F%3E%3C%2FfeMerge%3E%3C%2Ffilter%3E%3C%2Fsvg%3E%23filter');\\\\n}\\\\n\\\\n.highlight {\\\\n  filter: url(#highlight);\\\\n}\\\\n\\\\n.highlight {\\\\n  filter: url('#line-marker');\\\\n}\\\\n\\\\n@font-face {\\\\n  src: url(./font.woff) format('woff'),\\\\n    url('./font.woff2') format('woff2'),\\\\n    url(\\\\\\"./font.eot\\\\\\") format('eot'),\\\\n    /*url(~package/font.ttf) format('truetype'), */\\\\n    url(\\\\\\"./font with spaces.eot\\\\\\") format(\\\\\\"embedded-opentype\\\\\\"),\\\\n    url('./font.svg#svgFontName') format('svg'),\\\\n    url('./font.woff2?foo=bar') format('woff2'),\\\\n    url(\\\\\\"./font.eot?#iefix\\\\\\") format('embedded-opentype'),\\\\n    url(\\\\\\"./font with spaces.eot?#iefix\\\\\\") format('embedded-opentype');\\\\n}\\\\n\\\\n@media (min-width: 500px) {\\\\n  body {\\\\n    background: url(\\\\\\"./img.png\\\\\\");\\\\n  }\\\\n}\\\\n\\\\na {\\\\n  content: \\\\\\"do not use url(path)\\\\\\";\\\\n}\\\\n\\\\nb {\\\\n  content: 'do not \\\\\\"use\\\\\\" url(path)';\\\\n}\\\\n\\\\n@keyframes anim {\\\\n  background: green url('./img.png') xyz;\\\\n}\\\\n\\\\n.a {\\\\n  background-image: -webkit-image-set(url('./img1x.png') 1x, url('./img2x.png') 2x)\\\\n}\\\\n\\\\n.a {\\\\n  background-image: image-set(url('./img1x.png') 1x, url('./img2x.png') 2x)\\\\n}\\\\n\\\\n.class {\\\\n  background: green url() xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url('') xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\\\\\"\\\\\\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url('   ') xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\\\n  \\\\n  ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(https://raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"./img.png?foo\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"./img.png?foo=bar\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"./img.png?foo=bar#hash\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"./img.png?foo=bar#hash\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\\\\\"./img.png?\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url('./img.png') url(\\\\\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\\\\\") url('./img.png');\\\\n}\\\\n\\\\n.class {\\\\n  background: ___CSS_LOADER_URL___;\\\\n  background: ___CSS_LOADER_URL___INDEX___;\\\\n  background: ___CSS_LOADER_URL___99999___;\\\\n  background: ___CSS_LOADER_IMPORT___;\\\\n  background: ___CSS_LOADER_IMPORT___INDEX___;\\\\n  background: ___CSS_LOADER_IMPORT___99999___;\\\\n}\\\\n\\", \\"\\"]);
 
 // exports
 "
@@ -259,7 +259,7 @@ Array [
 }
 
 .class {
-  background: green url(/webpack/public/path/img.png) url(/webpack/public/path/other-img.png) xyz;
+  background: green  url(/webpack/public/path/other-img.png) xyz;
 }
 
 .class {
@@ -306,7 +306,7 @@ Array [
   src: url(/webpack/public/path/font.woff) format('woff'),
     url(/webpack/public/path/font.woff2) format('woff2'),
     url(/webpack/public/path/font.eot) format('eot'),
-    url(/webpack/public/path/font.ttf) format('truetype'),
+    
     url(\\"/webpack/public/path/font with spaces.eot\\") format(\\"embedded-opentype\\"),
     url(/webpack/public/path/font.svg#svgFontName) format('svg'),
     url(/webpack/public/path/font.woff2) format('woff2'),
@@ -353,7 +353,7 @@ b {
 }
 
 .class {
-  background: green url('') xyz;
+  background: green url('   ') xyz;
 }
 
 .class {
@@ -415,7 +415,7 @@ exports = module.exports = require(\\"../../../lib/runtime/api.js\\")(false);
 exports.i(require(\\"-!../../../index.js??ref--4-0!./imported.css\\"), \\"\\");
 
 // module
-exports.push([module.id, \\".class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\") + \\"#hash\\") + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"package/img.png\\")) + \\") url(\\" + escape(require(\\"./other-img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(/img.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\\\\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\\\\\"data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2042%2026%27%20fill%3D%27%2523007aff%27%3E%3Crect%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%271%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2711%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2712%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2722%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2723%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3C%2Fsvg%3E\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  filter: url('data:image/svg+xml;charset=utf-8,<svg xmlns=\\\\\\"http://www.w3.org/2000/svg\\\\\\"><filter id=\\\\\\"filter\\\\\\"><feGaussianBlur in=\\\\\\"SourceAlpha\\\\\\" stdDeviation=\\\\\\"0\\\\\\" /><feOffset dx=\\\\\\"1\\\\\\" dy=\\\\\\"2\\\\\\" result=\\\\\\"offsetblur\\\\\\" /><feFlood flood-color=\\\\\\"rgba(255,255,255,1)\\\\\\" /><feComposite in2=\\\\\\"offsetblur\\\\\\" operator=\\\\\\"in\\\\\\" /><feMerge><feMergeNode /><feMergeNode in=\\\\\\"SourceGraphic\\\\\\" /></feMerge></filter></svg>#filter');\\\\n}\\\\n\\\\n.class {\\\\n  filter: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%5C%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%5C%22%3E%3Cfilter%20id%3D%5C%22filter%5C%22%3E%3CfeGaussianBlur%20in%3D%5C%22SourceAlpha%5C%22%20stdDeviation%3D%5C%220%5C%22%20%2F%3E%3CfeOffset%20dx%3D%5C%221%5C%22%20dy%3D%5C%222%5C%22%20result%3D%5C%22offsetblur%5C%22%20%2F%3E%3CfeFlood%20flood-color%3D%5C%22rgba(255%2C255%2C255%2C1)%5C%22%20%2F%3E%3CfeComposite%20in2%3D%5C%22offsetblur%5C%22%20operator%3D%5C%22in%5C%22%20%2F%3E%3CfeMerge%3E%3CfeMergeNode%20%2F%3E%3CfeMergeNode%20in%3D%5C%22SourceGraphic%5C%22%20%2F%3E%3C%2FfeMerge%3E%3C%2Ffilter%3E%3C%2Fsvg%3E%23filter');\\\\n}\\\\n\\\\n.highlight {\\\\n  filter: url(#highlight);\\\\n}\\\\n\\\\n.highlight {\\\\n  filter: url('#line-marker');\\\\n}\\\\n\\\\n@font-face {\\\\n  src: url(\\" + escape(require(\\"./font.woff\\")) + \\") format('woff'),\\\\n    url(\\" + escape(require(\\"./font.woff2\\")) + \\") format('woff2'),\\\\n    url(\\" + escape(require(\\"./font.eot\\")) + \\") format('eot'),\\\\n    url(\\" + escape(require(\\"package/font.ttf\\")) + \\") format('truetype'),\\\\n    url(\\" + escape(require(\\"./font with spaces.eot\\")) + \\") format(\\\\\\"embedded-opentype\\\\\\"),\\\\n    url(\\" + escape(require(\\"./font.svg\\") + \\"#svgFontName\\") + \\") format('svg'),\\\\n    url(\\" + escape(require(\\"./font.woff2?foo=bar\\")) + \\") format('woff2'),\\\\n    url(\\" + escape(require(\\"./font.eot\\") + \\"?#iefix\\") + \\") format('embedded-opentype'),\\\\n    url(\\" + escape(require(\\"./font with spaces.eot\\") + \\"?#iefix\\") + \\") format('embedded-opentype');\\\\n}\\\\n\\\\n@media (min-width: 500px) {\\\\n  body {\\\\n    background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n  }\\\\n}\\\\n\\\\na {\\\\n  content: \\\\\\"do not use url(path)\\\\\\";\\\\n}\\\\n\\\\nb {\\\\n  content: 'do not \\\\\\"use\\\\\\" url(path)';\\\\n}\\\\n\\\\n@keyframes anim {\\\\n  background: green url(\\" + escape(require(\\"./img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.a {\\\\n  background-image: -webkit-image-set(url(\\" + escape(require(\\"./img1x.png\\")) + \\") 1x, url(\\" + escape(require(\\"./img2x.png\\")) + \\") 2x)\\\\n}\\\\n\\\\n.a {\\\\n  background-image: image-set(url(\\" + escape(require(\\"./img1x.png\\")) + \\") 1x, url(\\" + escape(require(\\"./img2x.png\\")) + \\") 2x)\\\\n}\\\\n\\\\n.class {\\\\n  background: green url() xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url('') xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\\\\\"\\\\\\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url('') xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\\\n  \\\\n  ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(https://raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?foo\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?foo=bar\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?foo=bar\\") + \\"#hash\\") + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?foo=bar\\") + \\"#hash\\") + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\" + escape(require(\\"./img.png\\")) + \\") url(\\\\\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\\\\\") url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: ___CSS_LOADER_URL___;\\\\n  background: ___CSS_LOADER_URL___INDEX___;\\\\n  background: ___CSS_LOADER_URL___99999___;\\\\n  background: ___CSS_LOADER_IMPORT___;\\\\n  background: ___CSS_LOADER_IMPORT___INDEX___;\\\\n  background: ___CSS_LOADER_IMPORT___99999___;\\\\n}\\\\n\\", \\"\\"]);
+exports.push([module.id, \\".class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\") + \\"#hash\\") + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green  url(\\" + escape(require(\\"./other-img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\" + escape(require(\\"./img img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(/img.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\\\\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\\\\\"data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2042%2026%27%20fill%3D%27%2523007aff%27%3E%3Crect%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%271%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2711%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2712%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2722%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2723%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3C%2Fsvg%3E\\\\\\");\\\\n}\\\\n\\\\n.class {\\\\n  filter: url('data:image/svg+xml;charset=utf-8,<svg xmlns=\\\\\\"http://www.w3.org/2000/svg\\\\\\"><filter id=\\\\\\"filter\\\\\\"><feGaussianBlur in=\\\\\\"SourceAlpha\\\\\\" stdDeviation=\\\\\\"0\\\\\\" /><feOffset dx=\\\\\\"1\\\\\\" dy=\\\\\\"2\\\\\\" result=\\\\\\"offsetblur\\\\\\" /><feFlood flood-color=\\\\\\"rgba(255,255,255,1)\\\\\\" /><feComposite in2=\\\\\\"offsetblur\\\\\\" operator=\\\\\\"in\\\\\\" /><feMerge><feMergeNode /><feMergeNode in=\\\\\\"SourceGraphic\\\\\\" /></feMerge></filter></svg>#filter');\\\\n}\\\\n\\\\n.class {\\\\n  filter: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%5C%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%5C%22%3E%3Cfilter%20id%3D%5C%22filter%5C%22%3E%3CfeGaussianBlur%20in%3D%5C%22SourceAlpha%5C%22%20stdDeviation%3D%5C%220%5C%22%20%2F%3E%3CfeOffset%20dx%3D%5C%221%5C%22%20dy%3D%5C%222%5C%22%20result%3D%5C%22offsetblur%5C%22%20%2F%3E%3CfeFlood%20flood-color%3D%5C%22rgba(255%2C255%2C255%2C1)%5C%22%20%2F%3E%3CfeComposite%20in2%3D%5C%22offsetblur%5C%22%20operator%3D%5C%22in%5C%22%20%2F%3E%3CfeMerge%3E%3CfeMergeNode%20%2F%3E%3CfeMergeNode%20in%3D%5C%22SourceGraphic%5C%22%20%2F%3E%3C%2FfeMerge%3E%3C%2Ffilter%3E%3C%2Fsvg%3E%23filter');\\\\n}\\\\n\\\\n.highlight {\\\\n  filter: url(#highlight);\\\\n}\\\\n\\\\n.highlight {\\\\n  filter: url('#line-marker');\\\\n}\\\\n\\\\n@font-face {\\\\n  src: url(\\" + escape(require(\\"./font.woff\\")) + \\") format('woff'),\\\\n    url(\\" + escape(require(\\"./font.woff2\\")) + \\") format('woff2'),\\\\n    url(\\" + escape(require(\\"./font.eot\\")) + \\") format('eot'),\\\\n    \\\\n    url(\\" + escape(require(\\"./font with spaces.eot\\")) + \\") format(\\\\\\"embedded-opentype\\\\\\"),\\\\n    url(\\" + escape(require(\\"./font.svg\\") + \\"#svgFontName\\") + \\") format('svg'),\\\\n    url(\\" + escape(require(\\"./font.woff2?foo=bar\\")) + \\") format('woff2'),\\\\n    url(\\" + escape(require(\\"./font.eot\\") + \\"?#iefix\\") + \\") format('embedded-opentype'),\\\\n    url(\\" + escape(require(\\"./font with spaces.eot\\") + \\"?#iefix\\") + \\") format('embedded-opentype');\\\\n}\\\\n\\\\n@media (min-width: 500px) {\\\\n  body {\\\\n    background: url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n  }\\\\n}\\\\n\\\\na {\\\\n  content: \\\\\\"do not use url(path)\\\\\\";\\\\n}\\\\n\\\\nb {\\\\n  content: 'do not \\\\\\"use\\\\\\" url(path)';\\\\n}\\\\n\\\\n@keyframes anim {\\\\n  background: green url(\\" + escape(require(\\"./img.png\\")) + \\") xyz;\\\\n}\\\\n\\\\n.a {\\\\n  background-image: -webkit-image-set(url(\\" + escape(require(\\"./img1x.png\\")) + \\") 1x, url(\\" + escape(require(\\"./img2x.png\\")) + \\") 2x)\\\\n}\\\\n\\\\n.a {\\\\n  background-image: image-set(url(\\" + escape(require(\\"./img1x.png\\")) + \\") 1x, url(\\" + escape(require(\\"./img2x.png\\")) + \\") 2x)\\\\n}\\\\n\\\\n.class {\\\\n  background: green url() xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url('') xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\\\\\"\\\\\\") xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url('   ') xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(\\\\n  \\\\n  ) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(https://raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz;\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?foo\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?foo=bar\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?foo=bar\\") + \\"#hash\\") + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?foo=bar\\") + \\"#hash\\") + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: url(\\" + escape(require(\\"./img.png?\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background-image: url(\\" + escape(require(\\"./img.png\\")) + \\") url(\\\\\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\\\\\") url(\\" + escape(require(\\"./img.png\\")) + \\");\\\\n}\\\\n\\\\n.class {\\\\n  background: ___CSS_LOADER_URL___;\\\\n  background: ___CSS_LOADER_URL___INDEX___;\\\\n  background: ___CSS_LOADER_URL___99999___;\\\\n  background: ___CSS_LOADER_IMPORT___;\\\\n  background: ___CSS_LOADER_IMPORT___INDEX___;\\\\n  background: ___CSS_LOADER_IMPORT___99999___;\\\\n}\\\\n\\", \\"\\"]);
 
 // exports
 "
@@ -438,7 +438,7 @@ Warning
   "ModuleWarning: Module Warning (from \`replaced original path\`):
 Warning
 
-(132:3) Unable to find uri in 'background: green url('') xyz'",
+(132:3) Unable to find uri in 'background: green url('   ') xyz'",
   "ModuleWarning: Module Warning (from \`replaced original path\`):
 Warning
 

--- a/test/fixtures/postcss-present-env/source.css
+++ b/test/fixtures/postcss-present-env/source.css
@@ -27,7 +27,7 @@ html {
 }
 
 .hero:matches(main, .main) {
-  background-image: image-set("img1x.png" 1x, "img2x.png" 2x);
+  background-image: image-set(url("./img1x.png") 1x, url("./img2x.png") 2x);
 }
 
 a {

--- a/test/fixtures/url/url.css
+++ b/test/fixtures/url/url.css
@@ -1,49 +1,49 @@
 @import "./imported.css";
 
 .class {
-  background: url('img.png');
+  background: url('./img.png');
 }
 
 .class {
-  background: url("img.png");
+  background: url("./img.png");
 }
 
 .class {
-  background: url(img.png);
+  background: url(./img.png);
 }
 
 .class {
-  background: url("img.png#hash");
+  background: url("./img.png#hash");
 }
 
 .class {
   background: url(
-    "img.png"
+    "./img.png"
   );
 }
 
 .class {
-  background: green url( 'img.png' ) xyz;
+  background: green url( './img.png' ) xyz;
 }
 
 .class {
-  background: green url( "img.png" ) xyz;
+  background: green url( "./img.png" ) xyz;
 }
 
 .class {
-  background: green url( img.png ) xyz;
+  background: green url( ./img.png ) xyz;
 }
 
 .class {
-  background: green url(~package/img.png) url(other-img.png) xyz;
+  background: green /* url(~package/img.png) */ url(./other-img.png) xyz;
 }
 
 .class {
-  background: green url( "img img.png" ) xyz;
+  background: green url( "./img img.png" ) xyz;
 }
 
 .class {
-  background: green url( 'img img.png' ) xyz;
+  background: green url( './img img.png' ) xyz;
 }
 
 .class {
@@ -79,20 +79,20 @@
 }
 
 @font-face {
-  src: url(font.woff) format('woff'),
-    url('font.woff2') format('woff2'),
-    url("font.eot") format('eot'),
-    url(~package/font.ttf) format('truetype'),
-    url("font with spaces.eot") format("embedded-opentype"),
-    url('font.svg#svgFontName') format('svg'),
-    url('font.woff2?foo=bar') format('woff2'),
-    url("font.eot?#iefix") format('embedded-opentype'),
-    url("font with spaces.eot?#iefix") format('embedded-opentype');
+  src: url(./font.woff) format('woff'),
+    url('./font.woff2') format('woff2'),
+    url("./font.eot") format('eot'),
+    /*url(~package/font.ttf) format('truetype'), */
+    url("./font with spaces.eot") format("embedded-opentype"),
+    url('./font.svg#svgFontName') format('svg'),
+    url('./font.woff2?foo=bar') format('woff2'),
+    url("./font.eot?#iefix") format('embedded-opentype'),
+    url("./font with spaces.eot?#iefix") format('embedded-opentype');
 }
 
 @media (min-width: 500px) {
   body {
-    background: url("img.png");
+    background: url("./img.png");
   }
 }
 
@@ -105,15 +105,15 @@ b {
 }
 
 @keyframes anim {
-  background: green url('img.png') xyz;
+  background: green url('./img.png') xyz;
 }
 
 .a {
-  background-image: -webkit-image-set(url('img1x.png') 1x, url('img2x.png') 2x)
+  background-image: -webkit-image-set(url('./img1x.png') 1x, url('./img2x.png') 2x)
 }
 
 .a {
-  background-image: image-set(url('img1x.png') 1x, url('img2x.png') 2x)
+  background-image: image-set(url('./img1x.png') 1x, url('./img2x.png') 2x)
 }
 
 .class {
@@ -146,27 +146,27 @@ b {
 }
 
 .class {
-  background: url("img.png?foo");
+  background: url("./img.png?foo");
 }
 
 .class {
-  background: url("img.png?foo=bar");
+  background: url("./img.png?foo=bar");
 }
 
 .class {
-  background: url("img.png?foo=bar#hash");
+  background: url("./img.png?foo=bar#hash");
 }
 
 .class {
-  background: url("img.png?foo=bar#hash");
+  background: url("./img.png?foo=bar#hash");
 }
 
 .class {
-  background: url("img.png?");
+  background: url("./img.png?");
 }
 
 .class {
-  background-image: url('img.png') url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>") url('img.png');
+  background-image: url('./img.png') url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>") url('./img.png');
 }
 
 .class {

--- a/test/getLocalIdent-option.test.js
+++ b/test/getLocalIdent-option.test.js
@@ -30,7 +30,7 @@ describe('getLocalIdent option', () => {
     const config = {
       loader: {
         options: {
-          modules: false,
+          modules: 'global',
           getLocalIdent() {
             return 'foo';
           },

--- a/test/import-option.test.js
+++ b/test/import-option.test.js
@@ -32,8 +32,8 @@ describe('import option', () => {
     expect(stats.compilation.errors).toMatchSnapshot('errors');
   });
 
-  [true, false].forEach((modulesValue) => {
-    it(`false and modules ${modulesValue}`, async () => {
+  [true, 'local', 'global', false].forEach((modulesValue) => {
+    it(`false and modules \`${modulesValue}\``, async () => {
       const config = {
         loader: { options: { import: false, modules: modulesValue } },
       };

--- a/test/modules-option.test.js
+++ b/test/modules-option.test.js
@@ -8,7 +8,7 @@ const testCases = fs.readdirSync(testCasesPath);
 
 describe('modules', () => {
   [false, true].forEach((exportOnlyLocalsValue) => {
-    [false, true].forEach((modulesValue) => {
+    [true, 'local', 'global', false].forEach((modulesValue) => {
       testCases.forEach((name) => {
         it(`case \`${name}\`: (export \`${
           exportOnlyLocalsValue ? 'only locals' : 'all'


### PR DESCRIPTION
BREAKING CHANGE: by default css modules are disabled (now `modules: false` disable css modules), you can return old behaviour change this on `modules: 'global'`

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Allow to disable css modules, some developers don't use `css` modules features and we decrease their perf.

### Breaking Changes

Yes

### Additional Info

No
