### PR TITLE
Safe checking if params are present

### DIFF
--- a/src/plugins/postcss-icss-parser.js
+++ b/src/plugins/postcss-icss-parser.js
@@ -76,7 +76,9 @@ export default postcss.plugin(
       // Replace tokens in at-rules
       css.walkAtRules((atrule) => {
         // eslint-disable-next-line no-param-reassign
-        atrule.params = replaceImportsInString(atrule.params.toString());
+        if (atrule.params) {
+          atrule.params = replaceImportsInString(atrule.params.toString());
+        }
       });
 
       // Replace tokens in export


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Tried today to use https://github.com/jonathantneal/postcss-font-magician to autoload Google Fonts and suddenly it was all broken with this error on the CSS:

```
throw new Error("Module build failed (from ../node_modules/extract-css-chunks-webpack-plugin/dist/loader.js):\nModuleBuildError: Module build failed (from ../node_modules/css-loader/dist/cjs.js):\nTypeError: Cannot read property 'toString' of undefined\n    at css.walkAtRules.atrule (./node_modules/css-loader/dist/plugins/postcss-icss-parser.js:82:58)\n    at ./node_modules/postcss/lib/container.js:295:18\n    at ./node_modules/postcss/lib/container.js:135:18\n    at Root.each (./node_modules/postcss/lib/container.js:101:16)\n    at Root.walk (./node_modules/postcss/lib/container.js:131:17)\n    at Root.walkAtRules (./node_modules/postcss/lib/container.js:293:19)\n    at process (./node_modules/css-loader/dist/plugins/postcss-icss-parser.js:80:7)\n    at LazyResult.run (./node_modules/postcss/lib/lazy-result.js:295:14)\n    at LazyResult.asyncTick (./node_modules/postcss/lib/lazy-result.js:208:26)\n    at LazyResult.asyncTick (./node_modules/postcss/lib/lazy-result.js:221:14)\n    at LazyResult.asyncTick (./node_modules/postcss/lib/lazy-result.js:221:14)\n    at ./node_modules/postcss/lib/lazy-result.js:250:14\n    at new Promise (<anonymous>)\n    at LazyResult.async (./node_modules/postcss/lib/lazy-result.js:246:23)\n    at LazyResult.then (./node_modules/postcss/lib/lazy-result.js:127:17)\n    at Object.loader (./node_modules/css-loader/dist/index.js:122:6)\n    at runLoaders (./node_modules/webpack/lib/NormalModule.js:301:20)\n    at ./node_modules/loader-runner/lib/LoaderRunner.js:364:11\n    at ./node_modules/loader-runner/lib/LoaderRunner.js:230:18\n    at context.callback (./node_modules/loader-runner/lib/LoaderRunner.js:111:13)\n    at process.then.catch.error (./node_modules/css-loader/dist/index.js:263:5)");
```

Digging a bit deeper I found that they use the `atRule` API by PostCSS as seen here: https://github.com/jonathantneal/postcss-font-magician/blob/master/index.js#L152 Double checked the API https://api.postcss.org/postcss.html#.atRule and it doesn't seem that the `params` parameter is something that's needed. 

I've double checked that all tests are still passing. Wasn't sure where to add a test for this little thing. Happy to add it wherever you may find it useful.