### PR TITLE
docs: sourceMaps are disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ module.exports = {
 ### `sourceMap`
 
 Type: `Boolean`
-Default: `true`
+Default: `false`
 
 To include source maps set the `sourceMap` option.
 


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Wrong docs ;) It's correct in the list of options docs and also in code it's by default `false`.

### Breaking Changes

None. 