### PR TITLE
fix: sourcemap generating when previous loader pass sourcemap as string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,9 @@ export default function loader(content, map, meta) {
   if (sourceMap) {
     if (map) {
       // Some loader emit source map as string
+      // Strip any JSON XSSI avoidance prefix from the string (as documented in the source maps specification), and then parse the string as JSON.
       if (typeof map === 'string') {
-        map = JSON.stringify(map);
+        map = JSON.parse(map.replace(/^\)]}'[^\n]*\n/, ''));
       }
 
       // Source maps should use forward slash because it is URLs (https://github.com/mozilla/source-map/issues/91)


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Previously we stringify string, it is invalid. No test, because we already have test on this

### Breaking Changes

No

### Additional Info

No