### PR TITLE
fix: invert `Function` behavior for `url` and `import` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,13 @@ module.exports = {
         options: {
           url: (url, resourcePath) => {
             // resourcePath - path to css file
+            
+            // Don't handle `img.png` urls
+            if (url.includes('img.png')) {
+              return false;
+            }
 
-            // `url()` with `img.png` stay untouched
-            return url.includes('img.png');
+            return true;
           },
         },
       },
@@ -262,8 +266,12 @@ module.exports = {
             // parsedImport.media - media query of `@import`
             // resourcePath - path to css file
 
-            // `@import` with `style.css` stay untouched
-            return parsedImport.url.includes('style.css');
+            // Don't handle `style.css` import
+            if (parsedImport.url.includes('style.css')) {
+              return false;
+            }
+
+            return true;
           },
         },
       },

--- a/src/utils.js
+++ b/src/utils.js
@@ -100,13 +100,13 @@ function getLocalIdent(loaderContext, localIdentName, localName, options) {
 }
 
 function getFilter(filter, resourcePath, defaultFilter = null) {
-  return (content) => {
-    if (defaultFilter && !defaultFilter(content)) {
+  return (item) => {
+    if (defaultFilter && !defaultFilter(item)) {
       return false;
     }
 
     if (typeof filter === 'function') {
-      return !filter(content, resourcePath);
+      return filter(item, resourcePath);
     }
 
     return true;

--- a/test/import-option.test.js
+++ b/test/import-option.test.js
@@ -62,7 +62,12 @@ describe('import option', () => {
           import: (parsedImport, resourcePath) => {
             expect(typeof resourcePath === 'string').toBe(true);
 
-            return parsedImport.url.includes('test.css');
+            // Don't handle `test.css`
+            if (parsedImport.url.includes('test.css')) {
+              return false;
+            }
+
+            return true;
           },
         },
       },

--- a/test/url-option.test.js
+++ b/test/url-option.test.js
@@ -62,7 +62,12 @@ describe('url option', () => {
           url: (url, resourcePath) => {
             expect(typeof resourcePath === 'string').toBe(true);
 
-            return url.includes('img.png');
+            // Don't handle `img.png`
+            if (url.includes('img.png')) {
+              return false;
+            }
+
+            return true;
           },
         },
       },


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #891

### Breaking Changes

Yes

BREAKING CHANGE: you should return `true` when you want handle `url`/`@import` and return `false` if not


### Additional Info

No