### PR TITLE
docs: fix `camelCase` reference in 3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ All notable changes to this project will be documented in this file. See [standa
 * minimum required nodejs version is 8.9.0
 * `@value` at rules now support in `selector`, recommends checking all `@values` at-rule usage (hint: you can add prefix to all `@value` at-rules, for example `@value v-foo: black;` or `@value m-foo: screen and (max-width: 12450px)`, and then do upgrade)
 * invert `{Function}` behavior for `url` and `import` options  (need return `true` when you want handle `url`/`@import` and return `false` if not)
-* `exportLocalsStyle` option was remove in favor `localsConvention` option, also it is accept only `{String}` value (use `camelCase` value if you previously value was `true` and `asIs` if you previously value was `false`) 
+* `camelCase` option was remove in favor `localsConvention` option, also it is accept only `{String}` value (use `camelCase` value if you previously value was `true` and `asIs` if you previously value was `false`)
 * `exportOnlyLocals` option was remove in favor `onlyLocals` option
 * `modules` option now can be `{Object}` and allow to setup `CSS Modules` options:
   * `localIdentName` option was removed in favor `modules.localIdentName` option


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

This specific line in the changelog comes from these two commits:
https://github.com/webpack-contrib/css-loader/pull/938
https://github.com/webpack-contrib/css-loader/pull/958
And it must be a typo to reference the old `camelCase` option as `exportLocalsStyle`

The release notes need to be updated, too https://github.com/webpack-contrib/css-loader/releases/tag/v3.0.0