### PR TITLE
fix: check for `url` being null before accessing `__esModules` property

### DIFF
--- a/src/runtime/getUrl.js
+++ b/src/runtime/getUrl.js
@@ -5,7 +5,7 @@ module.exports = (url, options) => {
   }
 
   // eslint-disable-next-line no-underscore-dangle, no-param-reassign
-  url = url.__esModule ? url.default : url;
+  url = url && url.__esModule ? url.default : url;
 
   if (typeof url !== 'string') {
     return url;

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -109,7 +109,7 @@ exports[`loader should compile with \`css\` entry point (with \`modules\` and sc
   }
 
   // eslint-disable-next-line no-underscore-dangle, no-param-reassign
-  url = url.__esModule ? url.default : url;
+  url = url && url.__esModule ? url.default : url;
 
   if (typeof url !== 'string') {
     return url;
@@ -414,7 +414,7 @@ exports[`loader should compile with \`css\` entry point (with \`modules\` and sc
   }
 
   // eslint-disable-next-line no-underscore-dangle, no-param-reassign
-  url = url.__esModule ? url.default : url;
+  url = url && url.__esModule ? url.default : url;
 
   if (typeof url !== 'string') {
     return url;
@@ -743,7 +743,7 @@ exports[`loader should compile with \`css\` entry point: escape 1`] = `
   }
 
   // eslint-disable-next-line no-underscore-dangle, no-param-reassign
-  url = url.__esModule ? url.default : url;
+  url = url && url.__esModule ? url.default : url;
 
   if (typeof url !== 'string') {
     return url;
@@ -1048,7 +1048,7 @@ exports[`loader should compile with \`js\` entry point: escape 1`] = `
   }
 
   // eslint-disable-next-line no-underscore-dangle, no-param-reassign
-  url = url.__esModule ? url.default : url;
+  url = url && url.__esModule ? url.default : url;
 
   if (typeof url !== 'string') {
     return url;
@@ -1547,7 +1547,7 @@ module.exports = (url, options) => {
   }
 
   // eslint-disable-next-line no-underscore-dangle, no-param-reassign
-  url = url.__esModule ? url.default : url;
+  url = url && url.__esModule ? url.default : url;
 
   if (typeof url !== 'string') {
     return url;
@@ -1824,7 +1824,7 @@ module.exports = (url, options) => {
   }
 
   // eslint-disable-next-line no-underscore-dangle, no-param-reassign
-  url = url.__esModule ? url.default : url;
+  url = url && url.__esModule ? url.default : url;
 
   if (typeof url !== 'string') {
     return url;


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Perhaps this is an unusual use case, but I'm using a custom final loader which can export `null` (i.e. the source is `module.exports = null`), e.g. if it determines a module will not be needed.

I suppose I could export an empty object, but in some cases I need to check if a module was removed in this manner, and it's easier to check for `null` which is falsy (as opposed to an empty object which is truthy.)

### Breaking Changes
n/a

### Additional Info
n/a
