### PR TITLE
fix: don't output invalid es5 code when locals do not exists

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -480,9 +480,9 @@ function getExportCode(
 
   if (exportType === 'locals') {
     exportItems.push(
-      `${
-        esModule ? 'export default' : 'module.exports ='
-      } {\n${exportLocalsCode}\n};`
+      `${esModule ? 'export default' : 'module.exports ='} ${
+        exportLocalsCode ? `{\n${exportLocalsCode}\n}` : '{}'
+      };`
     );
   } else {
     if (exportLocalsCode) {

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`loader issue #1033 (2): errors 1`] = `Array []`;
+
+exports[`loader issue #1033 (2): module 1`] = `
+"// Imports
+var ___CSS_LOADER_API_IMPORT___ = require(\\"../../../../src/runtime/api.js\\");
+exports = ___CSS_LOADER_API_IMPORT___(false);
+// Module
+exports.push([module.id, \\"\\", \\"\\"]);
+// Exports
+module.exports = exports;
+"
+`;
+
+exports[`loader issue #1033 (2): result 1`] = `
+Array [
+  Array [
+    "./modules/issue-1033/issue-1033.css",
+    "",
+    "",
+  ],
+]
+`;
+
+exports[`loader issue #1033 (2): warnings 1`] = `Array []`;
+
+exports[`loader issue #1033: errors 1`] = `Array []`;
+
+exports[`loader issue #1033: module 1`] = `
+"// Exports
+module.exports = {};
+"
+`;
+
+exports[`loader issue #1033: result 1`] = `Object {}`;
+
+exports[`loader issue #1033: warnings 1`] = `Array []`;
+
 exports[`loader should reuse \`ast\` from "postcss-loader": errors 1`] = `Array []`;
 
 exports[`loader should reuse \`ast\` from "postcss-loader": module 1`] = `

--- a/test/fixtures/modules/issue-1033/issue-1033.js
+++ b/test/fixtures/modules/issue-1033/issue-1033.js
@@ -1,0 +1,5 @@
+import css from './issue-1033.css';
+
+__export__ = css;
+
+export default css;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -308,4 +308,37 @@ describe('loader', () => {
     expect(getWarnings(stats)).toMatchSnapshot('warnings');
     expect(getErrors(stats)).toMatchSnapshot('errors');
   });
+
+  it('issue #1033', async () => {
+    const compiler = getCompiler('./modules/issue-1033/issue-1033.js', {
+      modules: { mode: 'local', localIdentName: '_[local]' },
+      onlyLocals: true,
+    });
+    const stats = await compile(compiler);
+
+    expect(
+      getModuleSource('./modules/issue-1033/issue-1033.css', stats)
+    ).toMatchSnapshot('module');
+    expect(getExecutedCode('main.bundle.js', compiler, stats)).toMatchSnapshot(
+      'result'
+    );
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
+
+  it('issue #1033 (2)', async () => {
+    const compiler = getCompiler('./modules/issue-1033/issue-1033.js', {
+      modules: { mode: 'local', localIdentName: '_[local]' },
+    });
+    const stats = await compile(compiler);
+
+    expect(
+      getModuleSource('./modules/issue-1033/issue-1033.css', stats)
+    ).toMatchSnapshot('module');
+    expect(getExecutedCode('main.bundle.js', compiler, stats)).toMatchSnapshot(
+      'result'
+    );
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #1033

### Breaking Changes

No

### Additional Info
