### PR TITLE
fix: do not output `undefined` when sourceRoot is unavailable

### DIFF
--- a/src/runtime/api.js
+++ b/src/runtime/api.js
@@ -58,7 +58,7 @@ function cssWithMappingToString(item, useSourceMap) {
   if (useSourceMap && typeof btoa === 'function') {
     const sourceMapping = toComment(cssMapping);
     const sourceURLs = cssMapping.sources.map(
-      (source) => `/*# sourceURL=${cssMapping.sourceRoot}${source} */`
+      (source) => `/*# sourceURL=${cssMapping.sourceRoot || ''}${source} */`
     );
 
     return [content]

--- a/test/runtime/__snapshots__/api.test.js.snap
+++ b/test/runtime/__snapshots__/api.test.js.snap
@@ -8,6 +8,12 @@ exports[`api should toString a single module 1`] = `"body { a: 1; }"`;
 
 exports[`api should toString multiple modules 1`] = `"body { b: 2; }body { a: 1; }"`;
 
+exports[`api should toString with a source map without "sourceRoot" 1`] = `
+"body { a: 1; }
+/*# sourceURL=./path/to/test.scss */
+/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJmaWxlIjoidGVzdC5zY3NzIiwic291cmNlcyI6WyIuL3BhdGgvdG8vdGVzdC5zY3NzIl0sIm1hcHBpbmdzIjoiQUFBQTsifQ== */"
+`;
+
 exports[`api should toString with media query 1`] = `"body { b: 2; }body { c: 3; }body { b: 2; }@media print {body { b: 2; }}@media print {body { d: 4; }}@media screen {body { a: 1; }}"`;
 
 exports[`api should toString with source mapping 1`] = `
@@ -16,4 +22,4 @@ exports[`api should toString with source mapping 1`] = `
 /*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJmaWxlIjoidGVzdC5zY3NzIiwic291cmNlcyI6WyIuL3BhdGgvdG8vdGVzdC5zY3NzIl0sIm1hcHBpbmdzIjoiQUFBQTsiLCJzb3VyY2VSb290Ijoid2VicGFjazovLyJ9 */"
 `;
 
-exports[`api should toString without source mapping if btoa not avalibale 1`] = `"body { a: 1; }"`;
+exports[`api should toString without source mapping if btoa not available 1`] = `"body { a: 1; }"`;

--- a/test/runtime/api.test.js
+++ b/test/runtime/api.test.js
@@ -101,7 +101,7 @@ describe('api', () => {
     expect(m.toString()).toMatchSnapshot();
   });
 
-  it('should toString without source mapping if btoa not avalibale', () => {
+  it('should toString without source mapping if btoa not available', () => {
     global.btoa = null;
 
     const m = api(true);
@@ -115,6 +115,23 @@ describe('api', () => {
         sources: ['./path/to/test.scss'],
         mappings: 'AAAA;',
         sourceRoot: 'webpack://',
+      },
+    ]);
+
+    expect(m.toString()).toMatchSnapshot();
+  });
+
+  it.only('should toString with a source map without "sourceRoot"', () => {
+    const m = api(true);
+
+    m.push([
+      1,
+      'body { a: 1; }',
+      '',
+      {
+        file: 'test.scss',
+        sources: ['./path/to/test.scss'],
+        mappings: 'AAAA;',
       },
     ]);
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #1034

### Breaking Changes

No

### Additional Info

https://github.com/mozilla/source-map/issues/340

sourceRoot is optional