### PR TITLE
feat: export default `getLocalIdent`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -74,7 +74,7 @@ function getLocalIdent(loaderContext, localIdentName, localName, options) {
       .replace(reRelativePath, '-')
       .replace(/\./g, '-'),
     { isIdentifier: true }
-  ).replace(/\\\[local\\\]/gi, localName);
+  ).replace(/\\\[local\\]/gi, localName);
 }
 
 function normalizeUrl(url, isStringValue) {
@@ -503,6 +503,7 @@ export {
   getModulesPlugins,
   normalizeSourceMap,
   getImportCode,
+  getLocalIdent,
   getModuleCode,
   getExportCode,
 };


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

For example, use default `getLocalIdent`, but override it's behavior for specific files:


```js
const getLocalIdent = require('css-loader/dist/utils').getLocalIdent;

...

            {
                loader: 'css-loader',
                options: {
                    modules: {
                        localIdentName: '[local]--[hash:base64:5]',
                        getLocalIdent: (context, localIdentName, localName, options) => getLocalIdent(
                            context,
                            context.resourcePath.endsWith('.modules.scss')
                                ? localIdentName
                                : '[local]',
                            localName,
                            options,
                        ),
                    },
                },
            }
```