### PR TITLE
fix: update schema of auto in modules

### DIFF
--- a/src/options.json
+++ b/src/options.json
@@ -39,7 +39,7 @@
             "auto": {
               "anyOf": [
                 {
-                  "type": "object"
+                  "instanceof": "RegExp"
                 },
                 {
                   "type": "boolean"


### PR DESCRIPTION
I updated schema of `auto` field in `modules` to `regexp` instead of `object`.