### PR TITLE
chore: don't test webpack 5 on node 8

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,6 +58,11 @@ jobs:
         node-version: [8.x, 10.x, 12.x, 14.x]
         webpack-version: [latest, next]
 
+        exclude:
+          # Webpack 5 does not support node 8
+          - node-version: 8.x
+            webpack-version: next
+
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Webpack 5 does not support node 8 and its test case does not run in that environment. This causes CI to fail as css-loader tries to run the test suite in node 8.

This PR skips running the webpack 5 test suite in node 8 so that future PRs can be green, per https://github.com/webpack-contrib/css-loader/pull/1086#issuecomment-636926156.

### Breaking Changes

n/a

### Additional Info

n/a