### PR TITLE
refactor: change function arguments of the `import` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,13 +262,11 @@ module.exports = {
         test: /\.css$/i,
         loader: 'css-loader',
         options: {
-          import: (parsedImport, resourcePath) => {
-            // parsedImport.url - url of `@import`
-            // parsedImport.media - media query of `@import`
+          import: (url, media, resourcePath) => {
             // resourcePath - path to css file
 
             // Don't handle `style.css` import
-            if (parsedImport.url.includes('style.css')) {
+            if (url.includes('style.css')) {
               return false;
             }
 

--- a/src/plugins/postcss-import-parser.js
+++ b/src/plugins/postcss-import-parser.js
@@ -140,7 +140,7 @@ export default postcss.plugin(pluginName, (options) => async (css, result) => {
       media = valueParser.stringify(mediaNodes).trim().toLowerCase();
     }
 
-    if (options.filter && !options.filter({ url: normalizedUrl, media })) {
+    if (options.filter && !options.filter(normalizedUrl, media)) {
       // eslint-disable-next-line no-continue
       continue;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -93,9 +93,9 @@ function requestify(url, rootContext) {
 }
 
 function getFilter(filter, resourcePath) {
-  return (item) => {
+  return (...args) => {
     if (typeof filter === 'function') {
-      return filter(item, resourcePath);
+      return filter(...args, resourcePath);
     }
 
     return true;

--- a/test/import-option.test.js
+++ b/test/import-option.test.js
@@ -52,11 +52,17 @@ describe('"import" option', () => {
 
   it('should work when "Function"', async () => {
     const compiler = getCompiler('./import/import.js', {
-      import: (parsedImport, resourcePath) => {
-        expect(typeof resourcePath === 'string').toBe(true);
+      import: (url, media, resourcePath) => {
+        expect(url).toBeDefined();
+
+        if (url === 'test-nested-media.css') {
+          expect(media).toBeDefined();
+        }
+
+        expect(resourcePath).toBeDefined();
 
         // Don't handle `test.css`
-        if (parsedImport.url.includes('test.css')) {
+        if (url.includes('test.css')) {
           return false;
         }
 


### PR DESCRIPTION
BREAKING CHANGE: function arguments of the `import` option were changed, it is now `funciton(url, media, resourcePath) {}`

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

For DX

### Breaking Changes

Yes

### Additional Info

No