### PR TITLE
examples of icss as well as syncing variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1438,7 +1438,7 @@ $colorBackground: red;
 ```scss
 @import "variables.scss";
 .componentClass {
-	background-color: $colorBackground;
+  background-color: $colorBackground;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1441,33 +1441,17 @@ $colorBackground: red;
 
 **Component.jsx**
 
-```javascript
-'use strict';
-
+```jsx
 import svars from 'variables.scss';
 import styles from 'Component.module.scss';
-import React, {useRef, useEffect} from 'react';
 
-const Component = () => {
-  const mountsGlCanvas = useRef();
-  useEffect(() => {
-    console.log('Hi there!');
-    return () => {
-      console.log('Bye!');
-    };
-  }, []);
-  return (
-    <div className={styles.componentClass}>
-      <canvas ref={mountsGlCanvas}/>
-    </div>
-  );
-};
+// render DOM with CSS modules class name
+// <div className={styles.componentClass}>
+//   <canvas ref={mountsCanvas}/>
+// </div>
 
-export default Component;
-
-// somewhere in canvas drawing code
-
-const ctx = mountsGlCanvas.current.getContext('2d', {alpha: false});
+// somewhere in JavaScript canvas drawing code use the variable directly
+// const ctx = mountsCanvas.current.getContext('2d',{alpha: false});
 ctx.fillStyle = `${svars.colorBackgroundCanvas}`;
 ```
 

--- a/README.md
+++ b/README.md
@@ -1243,6 +1243,237 @@ module.exports = {
 };
 ```
 
+
+### Using `Interoperable CSS` features only 
+
+The following setup is an example of allowing `Interoperable CSS` features such as `:import` and `:export` without using modules by setting `compileType` option.
+
+
+```javascript
+module.exports = {
+  module: {
+    rules: [
+      // ...
+      // --------
+      // SCSS
+      {
+        test: /\.scss$/,
+        exclude: /\.module\.scss$/,
+        use: [
+          {
+            loader: 'style-loader',
+            options: {}
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 3,
+              sourceMap: true,
+              modules: {
+                compileType: 'icss'
+              }
+            }
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'resolve-url-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true
+            }
+          }
+        ]
+      },
+      // --------
+      // ...
+    ]
+  }
+};
+```
+
+Using SCSS variables in JavaScript
+
+**variables.scss**
+
+```scss
+:export {
+  colorBackgroundCanvas: red;
+}
+```
+
+**app.js**
+
+```javascript
+import svars from 'variables.scss';
+
+ctx.fillStyle = `${svars.variableA}`;
+
+```
+
+### Using SCSS variables for both CSS modules and JavaScript if variables are defined in non-module files
+
+The following setup is an example of allowing `Interoperable CSS` features such as `:import` and `:export` without using modules (by setting `compileType` option) together with synchronizing variable values between CSS and Javascript.
+
+Assume case where one wants some canvas drawing to be the same color (set by color name) as HTML background (set by class name).
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      // ...
+      // --------
+      // SCSS GENERAL
+      {
+        test: /\.scss$/,
+        exclude: /\.module\.(scss)$/,
+        use: [
+          {
+            loader: 'style-loader',
+            options: {}
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 3,
+              sourceMap: true,
+              modules: {
+                compileType: 'icss'
+              }
+            }
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'resolve-url-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true
+            }
+          }
+        ]
+      },
+      // --------
+      // SCSS MODULES
+      {
+        test: /\.module\.scss$/,
+        use: [
+          {
+            loader: 'style-loader',
+            options: {}
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 3,
+              sourceMap: true,
+              modules: {
+                compileType: 'module',
+                mode: 'local',
+                exportGlobals: false,
+                namedExport: false,
+                exportLocalsConvention: 'asIs',
+                exportOnlyLocals: false
+              }
+            }
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'resolve-url-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true
+            }
+          }
+        ]
+      },
+      // --------
+      // ...
+    ]
+  }
+};
+```
+
+**variables.scss**
+
+```scss
+$colorBackground: red;
+:export {
+  colorBackgroundCanvas: $colorBackground;
+}
+```
+
+**Component.module.scss**
+
+```scss
+@import "variables.scss";
+.componentClass {
+	background-color: $colorBackground;
+}
+```
+
+**Component.jsx**
+
+```javascript
+'use strict';
+
+import svars from 'variables.scss';
+import styles from 'Component.module.scss';
+import React, {useRef, useEffect} from 'react';
+
+const Component = () => {
+  const mountsGlCanvas = useRef();
+  useEffect(() => {
+    console.log('Hi there!');
+    return () => {
+      console.log('Bye!');
+    };
+  }, []);
+  return (
+    <div className={styles.componentClass}>
+      <canvas ref={mountsGlCanvas}/>
+    </div>
+  );
+};
+
+export default Component;
+
+// somewhere in canvas drawing code
+
+const ctx = mountsGlCanvas.current.getContext('2d', {alpha: false});
+ctx.fillStyle = `${svars.variableA}`;
+```
+
 ## Contributing
 
 Please take a moment to read our contributing guidelines if you haven't yet done so.

--- a/README.md
+++ b/README.md
@@ -1244,12 +1244,13 @@ module.exports = {
 ```
 
 
-### Using `Interoperable CSS` features only 
+### Using `Interoperable CSS` features only
 
 The following setup is an example of allowing `Interoperable CSS` features such as `:import` and `:export` without using modules by setting `compileType` option.
 
+**webpack.config.js**
 
-```javascript
+```js
 module.exports = {
   module: {
     rules: [
@@ -1291,13 +1292,12 @@ module.exports = {
             options: {
               sourceMap: true
             }
-          }
-        ]
+          },
+        ],
       },
       // --------
       // ...
-    ]
-  }
+  },
 };
 ```
 
@@ -1313,11 +1313,9 @@ Using SCSS variables in JavaScript
 
 **app.js**
 
-```javascript
+```js
 import svars from 'variables.scss';
-
 ctx.fillStyle = `${svars.colorBackgroundCanvas}`;
-
 ```
 
 ### Using SCSS variables for both CSS modules and JavaScript if variables are defined in non-module files
@@ -1337,7 +1335,7 @@ module.exports = {
       // SCSS GENERAL
       {
         test: /\.scss$/,
-        exclude: /\.module\.(scss)$/,
+        exclude: /\.module\.scss$/,
         use: [
           {
             loader: 'style-loader',
@@ -1370,8 +1368,8 @@ module.exports = {
             options: {
               sourceMap: true
             }
-          }
-        ]
+          },
+        ],
       },
       // --------
       // SCSS MODULES
@@ -1414,13 +1412,12 @@ module.exports = {
             options: {
               sourceMap: true
             }
-          }
-        ]
+          },
+        ],
       },
       // --------
       // ...
-    ]
-  }
+  },
 };
 ```
 
@@ -1436,7 +1433,7 @@ $colorBackground: red;
 **Component.module.scss**
 
 ```scss
-@import "variables.scss";
+@import 'variables.scss';
 .componentClass {
   background-color: $colorBackground;
 }

--- a/README.md
+++ b/README.md
@@ -1316,7 +1316,7 @@ Using SCSS variables in JavaScript
 ```javascript
 import svars from 'variables.scss';
 
-ctx.fillStyle = `${svars.variableA}`;
+ctx.fillStyle = `${svars.colorBackgroundCanvas}`;
 
 ```
 
@@ -1471,7 +1471,7 @@ export default Component;
 // somewhere in canvas drawing code
 
 const ctx = mountsGlCanvas.current.getContext('2d', {alpha: false});
-ctx.fillStyle = `${svars.variableA}`;
+ctx.fillStyle = `${svars.colorBackgroundCanvas}`;
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1243,7 +1243,6 @@ module.exports = {
 };
 ```
 
-
 ### Using `Interoperable CSS` features only
 
 The following setup is an example of allowing `Interoperable CSS` features such as `:import` and `:export` without using modules by setting `compileType` option.


### PR DESCRIPTION
see https://github.com/webpack-contrib/css-loader/issues/1161

added two examples of 
* only icss and no modules
* variables in *only icss* mode and syncing it with both modules as well as JavaScript