### PR TITLE
Refactor - enable hideNothingWarning option by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,6 +157,7 @@ export default async function loader(content, map, meta) {
 
   try {
     result = await postcss(plugins).process(content, {
+      hideNothingWarning: true,
       from: resourcePath,
       to: resourcePath,
       map: options.sourceMap

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -449,4 +449,28 @@ describe('loader', () => {
     expect(getWarnings(stats)).toMatchSnapshot('warnings');
     expect(getErrors(stats)).toMatchSnapshot('errors');
   });
+
+  // TODO unskip after updating postcss to 8 version
+  it.skip('should not generate console.warn when plugins disabled and hideNothingWarning is "true"', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const compiler = getCompiler('./empty.js', {
+      import: false,
+      url: false,
+    });
+    const stats = await compile(compiler);
+
+    // eslint-disable-next-line no-console
+    expect(console.warn).not.toHaveBeenCalledWith(
+      'You did not set any plugins, parser, or stringifier. ' +
+        'Right now, PostCSS does nothing. Pick plugins for your case ' +
+        'on https://www.postcss.parts/ and use them in postcss.config.js.'
+    );
+    expect(getModuleSource('./empty.css', stats)).toMatchSnapshot('module');
+    expect(getExecutedCode('main.bundle.js', compiler, stats)).toMatchSnapshot(
+      'result'
+    );
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Enable `hideNothingWarning` postcss option by default, to disable console.warn when plugins are missing
`hideNothingWarning` option available in `poscss@8`

### Breaking Changes

No

### Additional Info

No
