### PR TITLE
Refactor emoji deprecate

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -210,6 +210,13 @@ function getModulesOptions(rawOptions, loaderContext) {
     }
   }
 
+  if (/\[emoji(?::(\d+))?\]/i.test(modulesOptions.localIdentName)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Emoji is deprecated and will be removed in next major release.'
+    );
+  }
+
   return modulesOptions;
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -211,8 +211,7 @@ function getModulesOptions(rawOptions, loaderContext) {
   }
 
   if (/\[emoji(?::(\d+))?\]/i.test(modulesOptions.localIdentName)) {
-    // eslint-disable-next-line no-console
-    console.warn(
+    loaderContext.emitWarning(
       'Emoji is deprecated and will be removed in next major release.'
     );
   }

--- a/test/__snapshots__/modules-option.test.js.snap
+++ b/test/__snapshots__/modules-option.test.js.snap
@@ -701,7 +701,12 @@ exports[`"modules" option should dedupe same modules in one module (issue #1037)
 
 exports[`"modules" option should emit warning when localIdentName is emoji: errors 1`] = `Array []`;
 
-exports[`"modules" option should emit warning when localIdentName is emoji: warnings 1`] = `Array []`;
+exports[`"modules" option should emit warning when localIdentName is emoji: warnings 1`] = `
+Array [
+  "ModuleWarning: Module Warning (from \`replaced original path\`):
+(Emitted value instead of an instance of Error) Emoji is deprecated and will be removed in next major release.",
+]
+`;
 
 exports[`"modules" option should keep order: errors 1`] = `Array []`;
 

--- a/test/__snapshots__/modules-option.test.js.snap
+++ b/test/__snapshots__/modules-option.test.js.snap
@@ -699,6 +699,10 @@ Array [
 
 exports[`"modules" option should dedupe same modules in one module (issue #1037): warnings 1`] = `Array []`;
 
+exports[`"modules" option should emit warning when localIdentName is emoji: errors 1`] = `Array []`;
+
+exports[`"modules" option should emit warning when localIdentName is emoji: warnings 1`] = `Array []`;
+
 exports[`"modules" option should keep order: errors 1`] = `Array []`;
 
 exports[`"modules" option should keep order: module 1`] = `

--- a/test/modules-option.test.js
+++ b/test/modules-option.test.js
@@ -1391,19 +1391,12 @@ describe('"modules" option', () => {
   });
 
   it('should emit warning when localIdentName is emoji', async () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
-
     const compiler = getCompiler('./modules/pure/pure.js', {
       modules: {
         localIdentName: '[emoji:0]',
       },
     });
     const stats = await compile(compiler);
-
-    // eslint-disable-next-line no-console
-    expect(console.warn).toHaveBeenCalledWith(
-      'Emoji is deprecated and will be removed in next major release.'
-    );
 
     expect(getWarnings(stats)).toMatchSnapshot('warnings');
     expect(getErrors(stats)).toMatchSnapshot('errors');

--- a/test/modules-option.test.js
+++ b/test/modules-option.test.js
@@ -1389,4 +1389,23 @@ describe('"modules" option', () => {
     expect(getWarnings(stats)).toMatchSnapshot('warnings');
     expect(getErrors(stats)).toMatchSnapshot('errors');
   });
+
+  it('should emit warning when localIdentName is emoji', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const compiler = getCompiler('./modules/pure/pure.js', {
+      modules: {
+        localIdentName: '[emoji:0]',
+      },
+    });
+    const stats = await compile(compiler);
+
+    // eslint-disable-next-line no-console
+    expect(console.warn).toHaveBeenCalledWith(
+      'Emoji is deprecated and will be removed in next major release.'
+    );
+
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Refactor emoji deprecate

### Breaking Changes

No

### Additional Info

No
