### PR TITLE
fix: handle inline loader syntax gracefully

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import {
   shouldUseURLPlugin,
   shouldUseIcssPlugin,
   getPreRequester,
+  combineRequests,
   getExportCode,
   getFilter,
   getImportCode,
@@ -79,7 +80,7 @@ export default async function loader(content, map, meta) {
         urlHandler: (url) =>
           stringifyRequest(
             this,
-            getPreRequester(this)(options.importLoaders) + url
+            combineRequests(getPreRequester(this)(options.importLoaders), url)
           ),
       })
     );
@@ -131,7 +132,7 @@ export default async function loader(content, map, meta) {
         urlHandler: (url) =>
           stringifyRequest(
             this,
-            getPreRequester(this)(options.importLoaders) + url
+            combineRequests(getPreRequester(this)(options.importLoaders), url)
           ),
       })
     );

--- a/src/utils.js
+++ b/src/utils.js
@@ -437,6 +437,16 @@ function getPreRequester({ loaders, loaderIndex }) {
   };
 }
 
+function combineRequests(preRequest, url) {
+  const idx = url.indexOf("!=!");
+  const combinedRequest =
+    idx !== -1
+      ? url.slice(0, idx + 3) + preRequest + url.slice(idx + 3)
+      : preRequest + url;
+
+  return combinedRequest;
+}
+
 function getImportCode(imports, options) {
   let code = "";
 
@@ -716,6 +726,7 @@ export {
   getModulesPlugins,
   normalizeSourceMap,
   getPreRequester,
+  combineRequests,
   getImportCode,
   getModuleCode,
   getExportCode,

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -225,6 +225,58 @@ You may need an appropriate loader to handle this file type, currently no loader
 
 exports[`loader should throws error when no loader(s) for assets: warnings 1`] = `Array []`;
 
+exports[`loader should work with !=! inline loader syntax: errors 1`] = `Array []`;
+
+exports[`loader should work with !=! inline loader syntax: module 1`] = `
+"// Imports
+import ___CSS_LOADER_API_IMPORT___ from \\"../../../src/runtime/api.js\\";
+var ___CSS_LOADER_EXPORT___ = ___CSS_LOADER_API_IMPORT___(function(i){return i[1]});
+// Module
+___CSS_LOADER_EXPORT___.push([module.id, \\".foo > .bar {\\\\n  color: red;\\\\n}\\", \\"\\"]);
+// Exports
+export default ___CSS_LOADER_EXPORT___;
+"
+`;
+
+exports[`loader should work with !=! inline loader syntax: module 2`] = `
+"// Imports
+import ___CSS_LOADER_API_IMPORT___ from \\"../../../src/runtime/api.js\\";
+var ___CSS_LOADER_EXPORT___ = ___CSS_LOADER_API_IMPORT___(function(i){return i[1]});
+// Module
+___CSS_LOADER_EXPORT___.push([module.id, \\".baz {\\\\n  width: 5px;\\\\n}\\", \\"\\"]);
+// Exports
+export default ___CSS_LOADER_EXPORT___;
+"
+`;
+
+exports[`loader should work with !=! inline loader syntax: result 1`] = `
+Array [
+  Array [
+    "Other.module.scss!=!../../src/index.js?[ident]!./inline-loader-syntax/modules.css",
+    ".foo > .bar {
+  color: red;
+}",
+    "",
+  ],
+  Array [
+    "Plain.scss!=!../../src/index.js?[ident]!./inline-loader-syntax/plain.css",
+    ".baz {
+  width: 5px;
+}",
+    "",
+  ],
+  Array [
+    "./inline-loader-syntax/entry.css",
+    ".foo > .bar {
+  color: red;
+}",
+    "",
+  ],
+]
+`;
+
+exports[`loader should work with !=! inline loader syntax: warnings 1`] = `Array []`;
+
 exports[`loader should work with "asset" module type: errors 1`] = `Array []`;
 
 exports[`loader should work with "asset" module type: module 1`] = `

--- a/test/fixtures/inline-loader-syntax/entry.css
+++ b/test/fixtures/inline-loader-syntax/entry.css
@@ -1,0 +1,13 @@
+
+@import 'Other.module.scss!=!./modules.css';
+
+@import 'Plain.scss!=!./plain.css';
+
+$color: red;
+
+// Uses Sass syntax
+.foo {
+  > .bar {
+    color: $color;
+  }
+}

--- a/test/fixtures/inline-loader-syntax/index.js
+++ b/test/fixtures/inline-loader-syntax/index.js
@@ -1,0 +1,5 @@
+import css from './entry.css';
+
+__export__ = css;
+
+export default css;

--- a/test/fixtures/inline-loader-syntax/modules.css
+++ b/test/fixtures/inline-loader-syntax/modules.css
@@ -1,0 +1,9 @@
+
+$color: red;
+
+// Uses Sass syntax
+.foo {
+  > .bar {
+    color: $color;
+  }
+}

--- a/test/fixtures/inline-loader-syntax/plain.css
+++ b/test/fixtures/inline-loader-syntax/plain.css
@@ -1,0 +1,7 @@
+
+// Uses Sass syntax
+$width: 1px + 4px;
+
+.baz {
+  width: $width
+}

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -524,4 +524,43 @@ describe("loader", () => {
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
     expect(getErrors(stats)).toMatchSnapshot("errors");
   });
+
+  it("should work with !=! inline loader syntax", async () => {
+    const compiler = getCompiler(
+      "./inline-loader-syntax/index.js",
+      {},
+      {
+        module: {
+          rules: [
+            {
+              test: /\.s?css$/i,
+              use: [
+                {
+                  loader: path.resolve(__dirname, "../src"),
+                  options: {
+                    importLoaders: 1,
+                    modules: { auto: true },
+                  },
+                },
+                "sass-loader",
+              ],
+            },
+          ],
+        },
+      }
+    );
+    const stats = await compile(compiler);
+
+    expect(
+      getModuleSource("./inline-loader-syntax/modules.css", stats)
+    ).toMatchSnapshot("module");
+    expect(
+      getModuleSource("./inline-loader-syntax/plain.css", stats)
+    ).toMatchSnapshot("module");
+    expect(getExecutedCode("main.bundle.js", compiler, stats)).toMatchSnapshot(
+      "result"
+    );
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
 });


### PR DESCRIPTION

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

css-loader was appending it's prefix to the beginning of the url, however it should go _after_ the `!=!` if it exists.

https://github.com/webpack/webpack/issues/11074

### Additional Info

The test demonstrates other ways this syntax is poorly supported by css-loader. Since the resource before `!=!` is only used to match loaders, (called `matchResource` by webpack source). Any resourcePath matching done by css-loader doesn't work here. 