### PR TITLE
fix: do not crash on unescaped svg data uri

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -98,10 +98,24 @@ function normalizeUrl(url, isStringValue) {
   }
 
   if (matchNativeWin32Path.test(url)) {
-    return decodeURI(normalizedUrl);
+    try {
+      normalizedUrl = decodeURI(normalizedUrl);
+    } catch (error) {
+      // Ignore
+    }
+
+    return normalizedUrl;
   }
 
-  return decodeURI(unescape(normalizedUrl));
+  normalizedUrl = unescape(normalizedUrl);
+
+  try {
+    normalizedUrl = decodeURI(normalizedUrl);
+  } catch (error) {
+    // Ignore
+  }
+
+  return normalizedUrl;
 }
 
 function requestify(url, rootContext) {

--- a/test/fixtures/url/url.css
+++ b/test/fixtures/url/url.css
@@ -389,6 +389,10 @@ a {
   background-image: image-set(url('./img.png', 'foo', './img.png', url('./img.png')) 1x, url("./img2x.png") 2x);
 }
 
+.button {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" style="stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px" /></svg>');
+}
+
 /* We need to use `resourceQuery: /inline/` */
 /* Hard to test on webpack v4 */
 /*.qqq {*/


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #1287

### Breaking Changes

No

### Additional Info

No