### PR TITLE
fix: remove asset experiment, fix test

### DIFF
--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -88,7 +88,6 @@ describe("loader", () => {
       },
     };
 
-    config.experiments = { asset: true };
     config.output = {
       path: path.resolve(__dirname, "outputs"),
       filename: "[name].bundle.js",


### PR DESCRIPTION
Assets enabled by default - https://github.com/webpack/webpack/pull/11413

No need in experiments 

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Fix CI, option enabled by default now

### Breaking Changes
no

### Additional Info
