### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -420,7 +420,7 @@ function defaultGetLocalIdent(
       path.relative(context, `${dirname + path.sep}_`)
     );
 
-    directory = directory.substr(0, directory.length - 1);
+    directory = directory.substring(0, directory.length - 1);
 
     let folder = "";
 

--- a/test/helpers/readAsset.js
+++ b/test/helpers/readAsset.js
@@ -10,7 +10,7 @@ export default (asset, compiler, stats) => {
   const queryStringIdx = targetFile.indexOf("?");
 
   if (queryStringIdx >= 0) {
-    targetFile = targetFile.substr(0, queryStringIdx);
+    targetFile = targetFile.slice(0, queryStringIdx);
   }
 
   try {


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
