### PR TITLE
docs: fix typo in url object syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Type:
 type url =
   | boolean
   | {
-      url: (url: string, resourcePath: string) => boolean;
+      filter: (url: string, resourcePath: string) => boolean;
     };
 ```
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The current documentation suggests that `url` can be set to an object with `url` as a property, whereas this should be `filter`