### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,7 +1,12 @@
 name: Cancel
 on: [push]
+permissions:
+  contents: read
+
 jobs:
   cancel:
+    permissions:
+      actions: write # for styfle/cancel-workflow-action to cancel/stop running workflows
     name: Cancel Previous Runs
     runs-on: ubuntu-latest
     timeout-minutes: 3


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflow runs:
https://github.com/webpack-contrib/css-loader/runs/8160728230?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflow:

- cancel.yml

The following workflow file already has the least privileged token permission set:

- nodejs.yml

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>

