### PR TITLE
feat: support regex in filter

### DIFF
--- a/src/options.json
+++ b/src/options.json
@@ -13,7 +13,16 @@
           "type": "object",
           "properties": {
             "filter": {
-              "instanceof": "Function"
+              "description": "Allows to custom `url()`/`image-set()` functions handling via regexp or function.",
+              "link": "https://github.com/webpack-contrib/css-loader#url",
+              "anyOf": [
+                {
+                  "instanceof": "RegExp"
+                },
+                {
+                  "instanceof": "Function"
+                }
+              ]
             }
           },
           "additionalProperties": false

--- a/src/utils.js
+++ b/src/utils.js
@@ -529,7 +529,9 @@ function getFilter(filter, resourcePath) {
     if (typeof filter === "function") {
       return filter(...args, resourcePath);
     }
-
+    if (filter instanceof RegExp) {
+      return filter.exec(...args);
+    }
     return true;
   };
 }

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -386,7 +386,18 @@ exports[`validate options should throw an error on the "url" option with "[]" va
 
 exports[`validate options should throw an error on the "url" option with "{"filter":true}" value 1`] = `
 "Invalid options object. CSS Loader has been initialized using an options object that does not match the API schema.
- - options.url.filter should be an instance of function."
+ - options.url should be one of these:
+   boolean | object { filter? }
+   -> Allows to enables/disables \`url()\`/\`image-set()\` functions handling.
+   -> Read more at https://github.com/webpack-contrib/css-loader#url
+   Details:
+    * options.url.filter should be one of these:
+      RegExp | function
+      -> Allows to custom \`url()\`/\`image-set()\` functions handling via regexp or function.
+      -> Read more at https://github.com/webpack-contrib/css-loader#url
+      Details:
+       * options.url.filter should be an instance of RegExp.
+       * options.url.filter should be an instance of function."
 `;
 
 exports[`validate options should throw an error on the "url" option with "{}" value 1`] = `

--- a/test/url-option.test.js
+++ b/test/url-option.test.js
@@ -629,4 +629,36 @@ describe('"url" option', () => {
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
     expect(getErrors(stats)).toMatchSnapshot("errors");
   });
+
+  it("should work with url.filter", async () => {
+    const compiler = getCompiler("./url/url.js", {
+      url: {
+        filter: /img/gm,
+      },
+    });
+    const stats = await compile(compiler);
+
+    expect(getModuleSource("./url/url.css", stats)).toMatchSnapshot("module");
+    expect(getExecutedCode("main.bundle.js", compiler, stats)).toMatchSnapshot(
+      "result"
+    );
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
+
+  it("should not work with url.filter", async () => {
+    const compiler = getCompiler("./url/url.js", {
+      url: {
+        filter: /broken/gm,
+      },
+    });
+    const stats = await compile(compiler);
+
+    expect(getModuleSource("./url/url.css", stats)).toMatchSnapshot("module");
+    expect(getExecutedCode("main.bundle.js", compiler, stats)).toMatchSnapshot(
+      "result"
+    );
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
 });


### PR DESCRIPTION
Makes running css-loader with advanced filter settings in worker possible.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [X] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

For thread-loader, setting functions as options is not allowed yet, but regex is. Therefore, supporting regex as a filter option for css-loader enables us to use the loader parallelized.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
