### PR TITLE
Updated generateExportEntry to expose node details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "postcss": "^8.4.29",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.3",
-        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-scope": "^3.1.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
         "semver": "^7.5.4"
@@ -13306,9 +13306,9 @@
       }
     },
     "node_modules/postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.1.0.tgz",
+      "integrity": "sha512-SaIbK8XW+MZbd0xHPf7kdfA/3eOt7vxJ72IRecn3EzuZVLr1r0orzf0MX/pN8m+NMDoo6X/SQd8oeKqGZd8PXg==",
       "dependencies": {
         "postcss-selector-parser": "^6.0.4"
       },
@@ -25674,9 +25674,9 @@
       }
     },
     "postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.1.0.tgz",
+      "integrity": "sha512-SaIbK8XW+MZbd0xHPf7kdfA/3eOt7vxJ72IRecn3EzuZVLr1r0orzf0MX/pN8m+NMDoo6X/SQd8oeKqGZd8PXg==",
       "requires": {
         "postcss-selector-parser": "^6.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "postcss": "^8.4.29",
     "postcss-modules-extract-imports": "^3.0.0",
     "postcss-modules-local-by-default": "^4.0.3",
-    "postcss-modules-scope": "^3.0.0",
+    "postcss-modules-scope": "^3.1.0",
     "postcss-modules-values": "^4.0.0",
     "postcss-value-parser": "^4.2.0",
     "semver": "^7.5.4"

--- a/src/utils.js
+++ b/src/utils.js
@@ -778,7 +778,7 @@ function getModulesPlugins(options, loaderContext) {
       localByDefault({ mode }),
       extractImports(),
       modulesScope({
-        generateScopedName(exportName) {
+        generateScopedName(exportName, resourceFile, rawCss, node) {
           let localIdent;
 
           if (typeof getLocalIdent !== "undefined") {
@@ -794,6 +794,7 @@ function getModulesPlugins(options, loaderContext) {
                 hashDigestLength: localIdentHashDigestLength,
                 hashStrategy,
                 regExp: localIdentRegExp,
+                node,
               }
             );
           }
@@ -813,6 +814,7 @@ function getModulesPlugins(options, loaderContext) {
                 hashDigestLength: localIdentHashDigestLength,
                 hashStrategy,
                 regExp: localIdentRegExp,
+                node,
               }
             );
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I would like the ability to only transform class names and not transform id. This is because keeping the original id is useful for anchoring (href="#section1") as well as code that rely on finding elements by id (automated tests, analytics, vanilla js, etc).
https://github.com/webpack-contrib/css-loader/issues/1540

### Breaking Changes

N/A

### Additional Info

Updated postcss-modules-scope dependency with latest which passes the node object to generateExportEntry. The node object has a "type" property that can be used to determine if the node is an id or class.