### PR TITLE
fix: keep order of `@import`s with the `webpackIgnore` comment

### DIFF
--- a/test/__snapshots__/import-option.test.js.snap
+++ b/test/__snapshots__/import-option.test.js.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`"import" option should jeep order of imports with 'webpackIgnore': errors 1`] = `[]`;
+
+exports[`"import" option should jeep order of imports with 'webpackIgnore': module 1`] = `
+"// Imports
+import ___CSS_LOADER_API_NO_SOURCEMAP_IMPORT___ from "../../../src/runtime/noSourceMaps.js";
+import ___CSS_LOADER_API_IMPORT___ from "../../../src/runtime/api.js";
+import ___CSS_LOADER_AT_RULE_IMPORT_0___ from "-!../../../src/index.js??ruleSet[1].rules[0].use[0]!./test.css";
+var ___CSS_LOADER_EXPORT___ = ___CSS_LOADER_API_IMPORT___(___CSS_LOADER_API_NO_SOURCEMAP_IMPORT___);
+___CSS_LOADER_EXPORT___.push([module.id, "@import url(/assets/themes.css);"]);
+___CSS_LOADER_EXPORT___.i(___CSS_LOADER_AT_RULE_IMPORT_0___);
+// Module
+___CSS_LOADER_EXPORT___.push([module.id, \`/*! /* webpackIgnore: true */
+
+body {
+  background: red;
+}
+\`, ""]);
+// Exports
+export default ___CSS_LOADER_EXPORT___;
+"
+`;
+
+exports[`"import" option should jeep order of imports with 'webpackIgnore': result 1`] = `
+"@import url(/assets/themes.css);.test {
+  a: a;
+}
+/*! /* webpackIgnore: true */
+
+body {
+  background: red;
+}
+"
+`;
+
+exports[`"import" option should jeep order of imports with 'webpackIgnore': warnings 1`] = `[]`;
+
 exports[`"import" option should keep original order: errors 1`] = `[]`;
 
 exports[`"import" option should keep original order: module 1`] = `

--- a/test/fixtures/import/webpackIgnore-order.css
+++ b/test/fixtures/import/webpackIgnore-order.css
@@ -1,0 +1,7 @@
+/*! /* webpackIgnore: true */
+@import url("/assets/themes.css");
+@import "~test";
+
+body {
+  background: red;
+}

--- a/test/fixtures/import/webpackIgnore-order.js
+++ b/test/fixtures/import/webpackIgnore-order.js
@@ -1,0 +1,5 @@
+import css from './webpackIgnore-order.css';
+
+__export__ = css.toString();
+
+export default css;

--- a/test/import-option.test.js
+++ b/test/import-option.test.js
@@ -588,4 +588,18 @@ describe('"import" option', () => {
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
     expect(getErrors(stats)).toMatchSnapshot("errors");
   });
+
+  it("should jeep order of imports with 'webpackIgnore'", async () => {
+    const compiler = getCompiler("./import/webpackIgnore-order.js");
+    const stats = await compile(compiler);
+
+    expect(
+      getModuleSource("./import/webpackIgnore-order.css", stats),
+    ).toMatchSnapshot("module");
+    expect(getExecutedCode("main.bundle.js", compiler, stats)).toMatchSnapshot(
+      "result",
+    );
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes https://github.com/webpack-contrib/css-loader/issues/1597

### Breaking Changes

No

### Additional Info

No