### PR TITLE
#1621 fix: correct escaping of backslashes in URL wrapping

### DIFF
--- a/src/runtime/getUrl.js
+++ b/src/runtime/getUrl.js
@@ -21,7 +21,7 @@ module.exports = (url, options) => {
   // Should url be wrapped?
   // See https://drafts.csswg.org/css-values-3/#urls
   if (/["'() \t\n]|(%20)/.test(url) || options.needQuotes) {
-    return `"${url.replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`;
+    return `"${url.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, "\\n')}"`;
   }
 
   return url;

--- a/src/runtime/getUrl.js
+++ b/src/runtime/getUrl.js
@@ -21,7 +21,7 @@ module.exports = (url, options) => {
   // Should url be wrapped?
   // See https://drafts.csswg.org/css-values-3/#urls
   if (/["'() \t\n]|(%20)/.test(url) || options.needQuotes) {
-    return `"${url.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, "\\n')}"`;
+    return `"${url.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`;
   }
 
   return url;

--- a/test/runtime/__snapshots__/getUrl.test.js.snap
+++ b/test/runtime/__snapshots__/getUrl.test.js.snap
@@ -85,3 +85,5 @@ exports[`escape should escape url 41`] = `""image other.png#hash""`;
 exports[`escape should escape url 42`] = `""image other.png#hash""`;
 
 exports[`escape should escape url 43`] = `""image other.png#hash""`;
+
+exports[`escape should escape url 44`] = `"http://url/path\\/"`;

--- a/test/runtime/__snapshots__/getUrl.test.js.snap
+++ b/test/runtime/__snapshots__/getUrl.test.js.snap
@@ -86,4 +86,4 @@ exports[`escape should escape url 42`] = `""image other.png#hash""`;
 
 exports[`escape should escape url 43`] = `""image other.png#hash""`;
 
-exports[`escape should escape url 44`] = `"http://url/path\\/"`;
+exports[`escape should escape url 44`] = `"https://www.example.com?path=path\\to\\resource"`;

--- a/test/runtime/getUrl.test.js
+++ b/test/runtime/getUrl.test.js
@@ -127,6 +127,8 @@ describe("escape", () => {
         { hash: "#hash", needQuotes: true },
       ),
     ).toMatchSnapshot();
-    expect(getUrl("http://url/path\\/")).toMatchSnapshot();
+    expect(
+      getUrl("https://www.example.com?path=path\\to\\resource"),
+    ).toMatchSnapshot();
   });
 });

--- a/test/runtime/getUrl.test.js
+++ b/test/runtime/getUrl.test.js
@@ -127,5 +127,6 @@ describe("escape", () => {
         { hash: "#hash", needQuotes: true },
       ),
     ).toMatchSnapshot();
+    expect(getUrl("http://url/path\\/")).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This PR contains a:

- [x ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fixing bug #1621 

### Breaking Changes

None

### Additional Info
