### PR TITLE
fix: strip BOM before process via PostCSS for 8.5.24

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ import {
   warningFactory,
   syntaxErrorFactory,
   supportTemplateLiteral,
+  stripBom,
 } from "./utils";
 
 export default async function loader(content, map, meta) {
@@ -174,7 +175,8 @@ export default async function loader(content, map, meta) {
   let result;
 
   try {
-    result = await postcss(plugins).process(content, {
+    // Since PostCSS 8.5.24 it does not strip BOM anymore
+    result = await postcss(plugins).process(stripBom(content), {
       hideNothingWarning: true,
       from: resourcePath,
       to: resourcePath,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1471,6 +1471,11 @@ function supportTemplateLiteral(loaderContext) {
   return false;
 }
 
+function stripBom(content) {
+  const BOM = 0xfeff;
+  return content.charCodeAt(0) === BOM ? content.slice(1) : content;
+}
+
 export {
   normalizeOptions,
   shouldUseModulesPlugins,
@@ -1499,4 +1504,5 @@ export {
   warningFactory,
   syntaxErrorFactory,
   supportTemplateLiteral,
+  stripBom,
 };

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -63,6 +63,42 @@ exports[`loader should not generate console.warn when plugins disabled and hideN
 
 exports[`loader should not generate console.warn when plugins disabled and hideNothingWarning is "true": warnings 1`] = `[]`;
 
+exports[`loader should not path BOM to postcss (issue #1678): errors 1`] = `[]`;
+
+exports[`loader should not path BOM to postcss (issue #1678): module 1`] = `
+"// Imports
+import ___CSS_LOADER_API_NO_SOURCEMAP_IMPORT___ from "../../../../src/runtime/noSourceMaps.js";
+import ___CSS_LOADER_API_IMPORT___ from "../../../../src/runtime/api.js";
+var ___CSS_LOADER_EXPORT___ = ___CSS_LOADER_API_IMPORT___(___CSS_LOADER_API_NO_SOURCEMAP_IMPORT___);
+// Module
+___CSS_LOADER_EXPORT___.push([module.id, \`.first::after {content:"©";}
+\`, ""]);
+// Exports
+export default ___CSS_LOADER_EXPORT___;
+"
+`;
+
+exports[`loader should not path BOM to postcss (issue #1678): module 2`] = `
+"// Imports
+import ___CSS_LOADER_API_NO_SOURCEMAP_IMPORT___ from "../../../../src/runtime/noSourceMaps.js";
+import ___CSS_LOADER_API_IMPORT___ from "../../../../src/runtime/api.js";
+var ___CSS_LOADER_EXPORT___ = ___CSS_LOADER_API_IMPORT___(___CSS_LOADER_API_NO_SOURCEMAP_IMPORT___);
+// Module
+___CSS_LOADER_EXPORT___.push([module.id, \`.second::after{content:"©";}
+\`, ""]);
+// Exports
+export default ___CSS_LOADER_EXPORT___;
+"
+`;
+
+exports[`loader should not path BOM to postcss (issue #1678): result 1`] = `
+".first::after {content:"©";}
+.second::after{content:"©";}
+"
+`;
+
+exports[`loader should not path BOM to postcss (issue #1678): warnings 1`] = `[]`;
+
 exports[`loader should pass queries to other loader: errors 1`] = `[]`;
 
 exports[`loader should pass queries to other loader: module 1`] = `

--- a/test/fixtures/modules/issue-1678/first.css
+++ b/test/fixtures/modules/issue-1678/first.css
@@ -1,0 +1,1 @@
+﻿.first::after {content:"©";}

--- a/test/fixtures/modules/issue-1678/second.css
+++ b/test/fixtures/modules/issue-1678/second.css
@@ -1,0 +1,1 @@
+﻿.second::after{content:"©";}

--- a/test/fixtures/modules/issue-1678/source.js
+++ b/test/fixtures/modules/issue-1678/source.js
@@ -1,0 +1,8 @@
+import cssFirst from './first.css';
+import cssSecond from './second.css';
+
+const css = cssFirst + cssSecond;
+
+__export__ = css;
+
+export default css;

--- a/test/fixtures/modules/issue-1678/with-bom-loader.js
+++ b/test/fixtures/modules/issue-1678/with-bom-loader.js
@@ -1,0 +1,1 @@
+module.exports = (content) => "\uFEFF" + content;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,5 +1,6 @@
 import path from "path";
 
+import postcss from "postcss";
 import postcssPresetEnv from "postcss-preset-env";
 
 import {
@@ -205,6 +206,57 @@ describe("loader", () => {
     );
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
     expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
+
+  it("should not path BOM to postcss (issue #1678)", async () => {
+    const postcssProcessSpy = jest.spyOn(
+      Object.getPrototypeOf(postcss()),
+      "process",
+    );
+
+    const compiler = getCompiler(
+      "./modules/issue-1678/source.js",
+      {},
+      {
+        module: {
+          rules: [
+            {
+              test: /\.css$/i,
+              use: [
+                {
+                  loader: path.resolve(__dirname, "../src"),
+                },
+                {
+                  // Emulate sass-loader@17 with production defaults
+                  // { sassOptions: { outputStyle: 'compressed', charset: true }}
+                  loader: "./modules/issue-1678/with-bom-loader.js",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    );
+
+    const stats = await compile(compiler);
+
+    expect(postcssProcessSpy).toHaveBeenCalledTimes(2);
+    for (const call of postcssProcessSpy.mock.calls) {
+      expect(call[0].startsWith("\uFEFF" /* BOM */)).toBe(false);
+    }
+    expect(
+      getModuleSource("./modules/issue-1678/first.css", stats),
+    ).toMatchSnapshot("module");
+    expect(
+      getModuleSource("./modules/issue-1678/second.css", stats),
+    ).toMatchSnapshot("module");
+    expect(getExecutedCode("source.js", compiler, stats)).toMatchSnapshot(
+      "result",
+    );
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+
+    postcssProcessSpy.mockRestore();
   });
 
   it('should work with "sass-loader"', async () => {


### PR DESCRIPTION
**Summary**

- Fix: https://github.com/webpack/css-loader/issues/1678
- Ref: https://github.com/postcss/postcss/pull/2119

1. Some loaders during a single CSS file processing add BOM
   - For example, `sass-loader` with the default production configuration:
     `{ sassOptions: { outputStyle: 'compressed', charset: true }}`
   - The result is valid as a single file compilation result
2. `css-loader` processes CSS via `postcss`
   - Before `postcss@8.5.24` it striped BOM
   - After `postcss@8.5.24` it preserves BOM
4. Problems:
   1. The result is different depending on the installed PostCSS patch version
   2. The result cannot be concatenated (for example, with `mini-css-extract-plugin`) - BOM will be in the middle.

This PR strips BOM before passing to `postcss`, basically copying `postcss`'s behavior before  `postcss@8.5.24`.

Alternatives could be:
- Strip BOM after processing, not before
- Consider it a problem of the concatenation side

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes, but I'm unsure if this is the kind of tests that are expected.
To have a propper integration test, we need to install postcss 8.5.24 or later.
Please let me know if I need to adjust the tests.

**Does this PR introduce a breaking change?**

No. It results is the same output from both `postcss` before and after `v8.5.24`.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

I don't think this needs to be documented because.

**Use of AI**

- No AI was used